### PR TITLE
Fix toolchain name when a bisect range bound lands on the default nightly's date

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -263,7 +263,15 @@ impl Toolchain {
             // N.B. We need to call this with a nonstandard name so that rustup utilizes the
             // fallback cargo logic.
             ToolchainSpec::Nightly { ref date } => {
-                format!("bisector-nightly-{}-{}", date.format("%Y-%m-%d"), self.host)
+                // `cargo-bisect-rustc` will avoid downloading nightlies if they are already
+                // installed. However, if the nightly toolchain is set as default, we need
+                // to refer to it using the rustup name, and not the nonstandard name
+                // given to downloaded nightlies.
+                if self.is_current_nightly() {
+                    "nightly".to_string()
+                } else {
+                    format!("bisector-nightly-{}-{}", date.format("%Y-%m-%d"), self.host)
+                }
             }
         }
     }


### PR DESCRIPTION
As described in https://rust-lang.zulipchat.com/#narrow/stream/217417-t-compiler.2Fcargo-bisect-rustc/topic/default.20nightly, whenever a bisection range bound lands on the date of the default nightly, bisection will fail silently, but blame the error on an inability to reproduce the regression (which is incorrect).

Manually launching the `--script` would succeed in reproducing the regression: the silent error making reproduction fail is actually a rustup error, as `cargo-bisect-rustc` is trying to pass one of the non-standard nightly names used for downloaded nightlies, for a nightly it didn't download, the default nightly.

I'm not sure this is the best fix, as I don't know the ramifications elsewhere in the code. I just made the code refer to the nighly with the "nightly" name, and not "bisector-nightly-*" (and manually verified the `RUSTUP_TOOLCHAIN` env variable using the erroneous case described in the zulip thread above).