### PR TITLE
Add shell scripts for use with cargo-bisect-rustc

### DIFF
--- a/scripts/deicer.sh
+++ b/scripts/deicer.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Copyright 2020 The Rust Project Developers
+#
+# Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+# http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+# http://opensource.org/licenses/MIT>, at your option. This file may not be
+# copied, modified, or distributed except according to those terms.
+
+! cargo build 2>&1 | grep "error: internal compiler error"

--- a/scripts/find.sh
+++ b/scripts/find.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Copyright 2020 The Rust Project Developers
+#
+# Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+# http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+# http://opensource.org/licenses/MIT>, at your option. This file may not be
+# copied, modified, or distributed except according to those terms.
+
+NEEDLE="E0642"
+
+! cargo build 2>&1 | grep "$NEEDLE"

--- a/scripts/findfix.sh
+++ b/scripts/findfix.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Copyright 2020 The Rust Project Developers
+#
+# Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+# http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+# http://opensource.org/licenses/MIT>, at your option. This file may not be
+# copied, modified, or distributed except according to those terms.
+
+! cargo build


### PR DESCRIPTION
This PR adds three shell scripts in a new `scripts` directory.  They support the following during bisections with this tool:

- `deicer.sh` - automate ICE identification during bisection with `cargo build`, returns exit status code 1 when the stderr substring `"error: internal compiler error"` is identified and ignores all other non-zero exit status code build fails (script workaround for https://github.com/rust-lang/cargo-bisect-rustc/issues/34). "regression" = ICE (only)
- `find.sh` - stdout/err stream substring search, returns exit status code 1 when stdout/err substring is identified.  "regression" = identified substring in stdout/err stream.
- `findfix.sh` - reverses the logic of the cargo build exit status to locate fixes - when build exits with 1, script exits with 0 and when build exits with 0, script exits with 1 (script workaround for https://github.com/rust-lang/cargo-bisect-rustc/issues/28 as recommended by [kennytm](https://github.com/rust-lang/cargo-bisect-rustc/issues/28#issuecomment-453554419)). "regression" = fix

If these are appropriate upstream, I'd be happy to add documentation in the tutorial or README.