### PR TITLE
Refactor start and end range regression check fails to Error from panic

### DIFF
--- a/src/least_satisfying.rs
+++ b/src/least_satisfying.rs
@@ -133,12 +133,18 @@ mod tests {
 
     #[test]
     fn least_satisfying_4() {
-        assert_eq!(least_satisfying(&[No, No, Yes, Yes, Yes], |i| *i).unwrap(), 2);
+        assert_eq!(
+            least_satisfying(&[No, No, Yes, Yes, Yes], |i| *i).unwrap(),
+            2
+        );
     }
 
     #[test]
     fn least_satisfying_5() {
-        assert_eq!(least_satisfying(&[No, Yes, Yes, Yes, Yes], |i| *i).unwrap(), 1);
+        assert_eq!(
+            least_satisfying(&[No, Yes, Yes, Yes, Yes], |i| *i).unwrap(),
+            1
+        );
     }
 
     #[test]
@@ -151,7 +157,10 @@ mod tests {
 
     #[test]
     fn least_satisfying_7() {
-        assert_eq!(least_satisfying(&[No, Yes, Unknown, Yes], |i| *i).unwrap(), 1);
+        assert_eq!(
+            least_satisfying(&[No, Yes, Unknown, Yes], |i| *i).unwrap(),
+            1
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1267,7 +1267,7 @@ fn bisect_nightlies(cfg: &Config, client: &Client) -> Result<BisectionResult, Er
                 Satisfies::Unknown
             }
         }
-    });
+    })?;
 
     Ok(BisectionResult {
         dl_spec,
@@ -1380,7 +1380,7 @@ fn bisect_ci_between(cfg: &Config, client: &Client, start: &str, end: &str) -> R
                 Satisfies::Unknown
             }
         }
-    });
+    })?;
 
     Ok(BisectionResult {
         searched: toolchains,
@@ -1401,7 +1401,7 @@ fn main() {
         match err.downcast::<ExitError>() {
             Ok(ExitError(code)) => process::exit(code),
             Err(err) => {
-                eprintln!("{}", err);
+                eprintln!("Error: {}", err);
                 process::exit(1);
             }
         }


### PR DESCRIPTION
This PR refactors the panics on start and end date regression checks in the `least_satisfying` function to `failure::Error` and adds error handling so that this propagates to the `run()` function.  

The user receives the error message and non-zero exit status code rather than a panic:

From:
```
verifying the end of the range reproduces the regression
std for x86_64-apple-darwin: 16.39 MB / 16.39 MB [============================] 100.00 % 11.44 MB/s uninstalling nightly-2020-02-03
tested nightly-2020-02-03, got No
thread 'main' panicked at 'the end of the range to test must reproduce the regression', /Users/chris/.cargo/registry/src/github.com-1ecc6299db9ec823/cargo-bisect-rustc-0.2.1/src/least_satisfying.rs:34:14
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```

to:

```
verifying the end of the range reproduces the regression
std for x86_64-apple-darwin: 16.39 MB / 16.39 MB [============================] 100.00 % 13.99 MB/s uninstalling nightly-2020-02-03
tested nightly-2020-02-03, got No
Error: the end of the range to test must reproduce the regression
```