### PR TITLE
Transition to Edition 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ name = "cargo-bisect-rustc"
 readme = "README.md"
 repository = "https://github.com/rust-lang/cargo-bisect-rustc"
 version = "0.2.1"
+edition = "2018"
 
 [dependencies]
 dialoguer = "0.3.0"

--- a/src/git.rs
+++ b/src/git.rs
@@ -26,7 +26,7 @@ pub struct Commit {
 
 impl Commit {
     // Takes &mut because libgit2 internally caches summaries
-    fn from_git2_commit(commit: &mut Git2Commit) -> Self {
+    fn from_git2_commit(commit: &mut Git2Commit<'_>) -> Self {
         Commit {
             sha: commit.id().to_string(),
             date: Utc.timestamp(commit.time().seconds(), 0),
@@ -83,7 +83,7 @@ pub fn get_commits_between(first_commit: &str, last_commit: &str) -> Result<Vec<
 
     // Sanity check -- our algorithm below only works reliably if the
     // two commits are merge commits made by bors
-    let assert_by_bors = |c: &Git2Commit| -> Result<(), Error> {
+    let assert_by_bors = |c: &Git2Commit<'_>| -> Result<(), Error> {
         match c.author().name() {
             Some("bors") => Ok(()),
             Some(author) => bail!("Expected author {} to be bors for {}", author, c.id()),

--- a/src/git.rs
+++ b/src/git.rs
@@ -13,9 +13,10 @@ const RUST_SRC_REPO: Option<&str> = option_env!("RUST_SRC_REPO");
 use std::path::Path;
 
 use chrono::{DateTime, TimeZone, Utc};
-use failure::Error;
+use failure::{bail, Error};
 use git2::build::RepoBuilder;
 use git2::{Commit as Git2Commit, Repository};
+use log::debug;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Commit {

--- a/src/least_satisfying.rs
+++ b/src/least_satisfying.rs
@@ -174,7 +174,7 @@ pub enum Satisfies {
 }
 
 impl fmt::Display for Satisfies {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,12 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-#[macro_use]
-extern crate failure;
-#[macro_use]
-extern crate log;
-
-
 use std::env;
 use std::ffi::OsString;
 use std::fmt;
@@ -22,8 +16,9 @@ use std::str::FromStr;
 
 use chrono::{Date, Duration, naive, Utc};
 use dialoguer::Select;
-use failure::Error;
+use failure::{bail, format_err, Fail, Error};
 use flate2::read::GzDecoder;
+use log::debug;
 use pbr::{ProgressBar, Units};
 use regex::Regex;
 use reqwest::header::CONTENT_LENGTH;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,27 +5,12 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-extern crate chrono;
-extern crate dialoguer;
-extern crate dirs;
-extern crate env_logger;
 #[macro_use]
 extern crate failure;
-extern crate flate2;
-extern crate git2;
 #[macro_use]
 extern crate log;
-extern crate pbr;
 #[cfg(test)]
 extern crate quickcheck;
-extern crate regex;
-extern crate reqwest;
-extern crate rustc_version;
-extern crate structopt;
-extern crate tar;
-extern crate tee;
-extern crate tempdir;
-extern crate xz2;
 
 use std::env;
 use std::ffi::OsString;

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,11 @@ use tee::TeeReader;
 use tempdir::TempDir;
 use xz2::read::XzDecoder;
 
+mod git;
+mod least_satisfying;
+
+use crate::least_satisfying::{least_satisfying, Satisfies};
+
 /// The first commit which build artifacts are made available through the CI for
 /// bisection.
 ///
@@ -46,10 +51,6 @@ const EPOCH_COMMIT: &str = "927c55d86b0be44337f37cf5b0a76fb8ba86e06c";
 
 const NIGHTLY_SERVER: &str = "https://static.rust-lang.org/dist";
 const CI_SERVER: &str = "https://s3-us-west-1.amazonaws.com/rust-lang-ci2";
-
-mod git;
-mod least_satisfying;
-use least_satisfying::{least_satisfying, Satisfies};
 
 fn get_commits(start: &str, end: &str) -> Result<Vec<git::Commit>, Error> {
     eprintln!("fetching commits from {} to {}", start, end);

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,7 @@
 extern crate failure;
 #[macro_use]
 extern crate log;
-#[cfg(test)]
-extern crate quickcheck;
+
 
 use std::env;
 use std::ffi::OsString;
@@ -219,7 +218,7 @@ impl Opts {
 struct ExitError(i32);
 
 impl fmt::Display for ExitError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "exiting with {}", self.0)
     }
 }
@@ -238,7 +237,7 @@ enum ToolchainSpec {
 }
 
 impl fmt::Display for ToolchainSpec {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             ToolchainSpec::Ci { ref commit, alt } => {
                 let alt_s = if alt { format!("-alt") } else { String::new() };
@@ -266,7 +265,7 @@ impl Toolchain {
 }
 
 impl fmt::Display for Toolchain {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.spec {
             ToolchainSpec::Ci { ref commit, alt } => {
                 let alt_s = if alt { format!("-alt") } else { String::new() };


### PR DESCRIPTION
This PR transitions the project to edition 2018

Includes:

- modify Cargo.toml with `edition = "2018"` field
- remove unnecessary extern crate declarations
- add explicit `crate` root path on use statement
- add explicit anonymous lifetime idioms with `cargo fix --edition-idioms`
- transition `#[macro_use]` attributes to use statements