### PR TITLE
[WIP] Expand error handling support

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,58 @@
+// Copyright 2018 The Rust Project Developers
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! Custom errors for cargo-bisect-rustc
+
+use std::fmt;
+use std::io;
+
+use failure::Fail;
+
+use super::ToolchainSpec;
+
+#[derive(Fail, Debug)]
+pub(crate) enum ArchiveError {
+    #[fail(display = "Failed to parse archive: {}", _0)]
+    Archive(#[cause] io::Error),
+    #[fail(display = "Failed to create directory: {}", _0)]
+    CreateDir(#[cause] io::Error),
+}
+
+#[derive(Fail, Debug)]
+#[fail(display = "will never happen")]
+pub(crate) struct BoundParseError {}
+
+#[derive(Fail, Debug)]
+pub(crate) enum DownloadError {
+    #[fail(display = "Tarball not found at {}", _0)]
+    NotFound(String),
+    #[fail(display = "A reqwest error occurred: {}", _0)]
+    Reqwest(#[cause] reqwest::Error),
+    #[fail(display = "An archive error occurred: {}", _0)]
+    Archive(#[cause] ArchiveError),
+}
+
+#[derive(Debug, Fail)]
+pub(crate) struct ExitError(i32);
+
+impl fmt::Display for ExitError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "exiting with {}", self.0)
+    }
+}
+
+#[derive(Fail, Debug)]
+pub(crate) enum InstallError {
+    #[fail(display = "Could not find {}; url: {}", spec, url)]
+    NotFound { url: String, spec: ToolchainSpec },
+    #[fail(display = "Could not download toolchain: {}", _0)]
+    Download(#[cause] DownloadError),
+    #[fail(display = "Could not create tempdir: {}", _0)]
+    TempDir(#[cause] io::Error),
+    #[fail(display = "Could not move tempdir into destination: {}", _0)]
+    Move(#[cause] io::Error),
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -23,10 +23,6 @@ pub(crate) enum ArchiveError {
 }
 
 #[derive(Fail, Debug)]
-#[fail(display = "will never happen")]
-pub(crate) struct NeverError {}
-
-#[derive(Fail, Debug)]
 pub(crate) enum DownloadError {
     #[fail(display = "Tarball not found at {}", _0)]
     NotFound(String),
@@ -51,3 +47,7 @@ pub(crate) enum InstallError {
     #[fail(display = "Could not move tempdir into destination: {}", _0)]
     Move(#[cause] io::Error),
 }
+
+#[derive(Fail, Debug)]
+#[fail(display = "will never happen")]
+pub(crate) struct NeverError {}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -24,7 +24,7 @@ pub(crate) enum ArchiveError {
 
 #[derive(Fail, Debug)]
 #[fail(display = "will never happen")]
-pub(crate) struct BoundParseError {}
+pub(crate) struct NeverError {}
 
 #[derive(Fail, Debug)]
 pub(crate) enum DownloadError {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -7,7 +7,6 @@
 
 //! Custom errors for cargo-bisect-rustc
 
-use std::fmt;
 use std::io;
 
 use failure::Fail;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -37,13 +37,8 @@ pub(crate) enum DownloadError {
 }
 
 #[derive(Debug, Fail)]
-pub(crate) struct ExitError(i32);
-
-impl fmt::Display for ExitError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "exiting with {}", self.0)
-    }
-}
+#[fail(display = "exiting with {}", _0)]
+pub(crate) struct ExitStatusError(pub(crate) i32);
 
 #[derive(Fail, Debug)]
 pub(crate) enum InstallError {

--- a/src/least_satisfying.rs
+++ b/src/least_satisfying.rs
@@ -133,12 +133,18 @@ mod tests {
 
     #[test]
     fn least_satisfying_4() {
-        assert_eq!(least_satisfying(&[No, No, Yes, Yes, Yes], |i| *i).unwrap(), 2);
+        assert_eq!(
+            least_satisfying(&[No, No, Yes, Yes, Yes], |i| *i).unwrap(),
+            2
+        );
     }
 
     #[test]
     fn least_satisfying_5() {
-        assert_eq!(least_satisfying(&[No, Yes, Yes, Yes, Yes], |i| *i).unwrap(), 1);
+        assert_eq!(
+            least_satisfying(&[No, Yes, Yes, Yes, Yes], |i| *i).unwrap(),
+            1
+        );
     }
 
     #[test]
@@ -151,7 +157,10 @@ mod tests {
 
     #[test]
     fn least_satisfying_7() {
-        assert_eq!(least_satisfying(&[No, Yes, Unknown, Yes], |i| *i).unwrap(), 1);
+        assert_eq!(
+            least_satisfying(&[No, Yes, Unknown, Yes], |i| *i).unwrap(),
+            1
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1232,7 +1232,7 @@ fn bisect_nightlies(cfg: &Config, client: &Client) -> Result<BisectionResult, Er
                 Satisfies::Unknown
             }
         }
-    });
+    })?;
 
     Ok(BisectionResult {
         dl_spec,
@@ -1345,7 +1345,7 @@ fn bisect_ci_between(cfg: &Config, client: &Client, start: &str, end: &str) -> R
                 Satisfies::Unknown
             }
         }
-    });
+    })?;
 
     Ok(BisectionResult {
         searched: toolchains,
@@ -1366,7 +1366,7 @@ fn main() {
         match err.downcast::<ExitStatusError>() {
             Ok(ExitStatusError(code)) => process::exit(code),
             Err(err) => {
-                eprintln!("{}", err);
+                eprintln!("Error: {}", err);
                 process::exit(1);
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,10 +68,10 @@ mod least_satisfying;
 use least_satisfying::{least_satisfying, Satisfies};
 use errors::{
     ArchiveError,
-    BoundParseError,
     DownloadError,
     ExitStatusError,
     InstallError,
+    NeverError,
 };
 
 fn get_commits(start: &str, end: &str) -> Result<Vec<git::Commit>, Error> {
@@ -194,8 +194,8 @@ enum Bound {
 }
 
 impl FromStr for Bound {
-    type Err = BoundParseError;
-    fn from_str(s: &str) -> Result<Bound, BoundParseError> {
+    type Err = NeverError;
+    fn from_str(s: &str) -> Result<Bound, NeverError> {
         match chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d") {
             Ok(date) => Ok(Bound::Date(Date::from_utc(date, Utc))),
             Err(_) => Ok(Bound::Commit(s.to_string())),

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,7 @@ use errors::{
     ArchiveError,
     BoundParseError,
     DownloadError,
-    ExitError,
+    ExitStatusError,
     InstallError,
 };
 
@@ -1363,8 +1363,8 @@ struct BisectionResult {
 
 fn main() {
     if let Err(err) = run() {
-        match err.downcast::<ExitError>() {
-            Ok(ExitError(code)) => process::exit(code),
+        match err.downcast::<ExitStatusError>() {
+            Ok(ExitStatusError(code)) => process::exit(code),
             Err(err) => {
                 eprintln!("{}", err);
                 process::exit(1);


### PR DESCRIPTION
This PR refactors existing custom errors to a new `errors.rs` module and replaces panics with error handling support across all source files. 

WIP =>  `Result` return types were added across all functions that raise errors; however, I need input on how to work the error handling through the `least_satisfying` closures in:

https://github.com/rust-lang/cargo-bisect-rustc/blob/7ac03973cd216782fe93858d14e5897f409732d8/src/main.rs#L1249-L1270

and 

https://github.com/rust-lang/cargo-bisect-rustc/blob/7ac03973cd216782fe93858d14e5897f409732d8/src/main.rs#L1360-L1383

At the moment, the errors raised in the Toolchain.test method will still panic during the `least_satisfying` tests.

Fixes #16 
Supersedes https://github.com/rust-lang/cargo-bisect-rustc/pull/48

---

### TODO

- [ ] eliminate panics in the `least_satisfying` part of `bisect_nightlies`
- [ ] eliminate panics in the `least_satisfying` part of `bisect_ci_between`