### PR TITLE
Add support for Github API for querying repository info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,6 +141,8 @@ dependencies = [
  "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "tee 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1099,7 +1101,8 @@ dependencies = [
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1192,8 +1195,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "serde_json"
@@ -1202,7 +1218,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1212,7 +1228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1512,7 +1528,7 @@ version = "0.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-macro 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1818,7 +1834,8 @@ dependencies = [
 "checksum security-framework-sys 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9636f8989cbf61385ae4824b98c1aaa54c994d7d8b41f11c601ed799f0549a56"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4b39bd9b0b087684013a792c59e3e07a46a01d2322518d8a1104641a0b1be0"
+"checksum serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
+"checksum serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
 "checksum serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)" = "2f72eb2a68a7dc3f9a691bfda9305a1c017a6215e5a4545c258500d2099a37c2"
 "checksum serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,10 @@ git2 = "0.11"
 log = "0.4"
 pbr = "1.0.2"
 regex = "1.3.4"
-reqwest = { version = "0.10.2", features = ["blocking"] }
+reqwest = { version = "0.10.2", features = ["blocking", "json"] }
 rustc_version = "0.2"
+serde = { version = "1.0.104", features = ["derive"] }
+serde_json = "1.0"
 structopt = "0.3.9"
 tar = "0.4"
 tee = "0.1"

--- a/src/git.rs
+++ b/src/git.rs
@@ -62,10 +62,10 @@ fn get_repo() -> Result<Repository, Error> {
     }
 }
 
-pub fn expand_commit(sha: &str) -> Result<String, Error> {
+pub(crate) fn get_commit(sha: &str) -> Result<Commit, Error> {
     let repo = get_repo()?;
-    let rev = lookup_rev(&repo, sha)?;
-    Ok(rev.id().to_string())
+    let mut rev = lookup_rev(&repo, sha)?;
+    Ok(Commit::from_git2_commit(&mut rev))
 }
 
 /// Returns the bors merge commits between the two specified boundaries

--- a/src/git.rs
+++ b/src/git.rs
@@ -12,18 +12,13 @@ const RUST_SRC_REPO: Option<&str> = option_env!("RUST_SRC_REPO");
 
 use std::path::Path;
 
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{TimeZone, Utc};
 use failure::{bail, Error};
 use git2::build::RepoBuilder;
 use git2::{Commit as Git2Commit, Repository};
 use log::debug;
 
-#[derive(Debug, Clone, PartialEq)]
-pub struct Commit {
-    pub sha: String,
-    pub date: DateTime<Utc>,
-    pub summary: String,
-}
+use crate::Commit;
 
 impl Commit {
     // Takes &mut because libgit2 internally caches summaries

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,0 +1,167 @@
+use failure::Error;
+use reqwest::{self, blocking::Client, blocking::Response};
+use serde::{Deserialize, Serialize};
+
+use crate::Commit;
+
+#[derive(Serialize, Deserialize, Debug)]
+struct GithubCommitElem { commit: GithubCommit, sha: String }
+#[derive(Serialize, Deserialize, Debug)]
+struct GithubCommit { author: GithubAuthor, committer: GithubAuthor, message: String, }
+#[derive(Serialize, Deserialize, Debug)]
+struct GithubAuthor { date: String, email: String, name: String }
+
+type GitDate = chrono::DateTime<chrono::Utc>;
+
+impl GithubCommitElem {
+    fn date(&self) -> Result<GitDate, Error> {
+        Ok(self.commit.committer.date.parse()?)
+    }
+
+    fn git_commit(self) -> Result<Commit, Error> {
+        let date = self.date()?;
+        Ok(Commit {
+            sha: self.sha,
+            date,
+            summary: self.commit.message,
+        })
+    }
+}
+
+fn headers() -> Result<reqwest::header::HeaderMap, Error> {
+    let mut headers = reqwest::header::HeaderMap::new();
+    let user_agent = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
+    let user_agent = reqwest::header::HeaderValue::from_static(user_agent);
+    headers.insert(reqwest::header::USER_AGENT, user_agent);
+    if let Ok(token) = std::env::var("GITHUB_TOKEN") {
+        eprintln!("adding local env GITHUB_TOKEN value to headers in github query");
+        let value = reqwest::header::HeaderValue::from_str(&format!("token {}", token))?;
+        headers.insert(reqwest::header::AUTHORIZATION, value);
+    }
+    Ok(headers)
+}
+
+pub(crate) fn get_commit(sha: &str) -> Result<Commit, Error> {
+    let url = SingleCommitUrl { sha }.url();
+    let client = Client::builder()
+        .default_headers(headers()?)
+        .build()?;
+    let response: Response = client.get(&url).send()?;
+    let elem: GithubCommitElem = response.json()?;
+    elem.git_commit()
+}
+
+#[derive(Copy, Clone, Debug)]
+pub(crate) struct CommitsQuery<'a> {
+    pub since_date: &'a str,
+    pub most_recent_sha: &'a str,
+    pub earliest_sha: &'a str,
+}
+
+/// Returns the bors merge commits between the two specified boundaries
+/// (boundaries inclusive).
+
+impl<'a> CommitsQuery<'a> {
+    pub fn get_commits(&self) -> Result<Vec<Commit>, Error> {
+        get_commits(*self)
+    }
+}
+
+const PER_PAGE: usize = 100;
+const OWNER: &'static str = "rust-lang";
+const REPO: &'static str = "rust";
+
+
+trait ToUrl { fn url(&self) -> String; }
+struct CommitsUrl<'a> { page: usize, author: &'a str, since: &'a str, sha: &'a str }
+struct SingleCommitUrl<'a> { sha: &'a str }
+
+impl<'a> ToUrl for CommitsUrl<'a> {
+    fn url(&self) -> String {
+        format!("https://api.github.com/repos/{OWNER}/{REPO}/commits\
+                 ?page={PAGE}&per_page={PER_PAGE}\
+                 &author={AUTHOR}&since={SINCE}&sha={SHA}",
+                OWNER=OWNER, REPO=REPO,
+                PAGE=self.page, PER_PAGE=PER_PAGE,
+                AUTHOR=self.author, SINCE=self.since, SHA=self.sha)
+    }
+}
+
+impl<'a> ToUrl for SingleCommitUrl<'a> {
+    fn url(&self) -> String {
+        format!("https://api.github.com/repos/{OWNER}/{REPO}/commits/{REF}",
+                OWNER=OWNER, REPO=REPO, REF=self.sha)
+    }
+}
+
+fn get_commits(q: CommitsQuery) -> Result<Vec<Commit>, Error> {
+    // build up commit sequence, by feeding in `sha` as the starting point, and
+    // working way backwards to max(`q.since_date`, `q.earliest_sha`).
+    let mut commits = Vec::new();
+
+    // focus on Pull Request merges, all authored and committed by bors.
+    let author = "bors";
+
+    let client = Client::builder()
+        .default_headers(headers()?)
+        .build()?;
+    for page in 1.. {
+        let url = CommitsUrl { page, author, since: q.since_date, sha: q.most_recent_sha }.url();
+
+        let response: Response = client.get(&url).send()?;
+
+        let action = parse_paged_elems(response, |elem: GithubCommitElem| {
+            let date: chrono::DateTime<chrono::Utc> = match elem.commit.committer.date.parse() {
+                Ok(date) => date,
+                Err(err) => return Loop::Err(err.into()),
+            };
+            let sha = elem.sha.clone();
+            let summary = elem.commit.message;
+            let commit = Commit { sha, date, summary };
+            commits.push(commit);
+
+            if elem.sha == q.earliest_sha {
+                eprintln!("ending github query because we found starting sha: {}", elem.sha);
+                return Loop::Break;
+            }
+
+            Loop::Next
+        })?;
+
+        if let Loop::Break = action { break; }
+    }
+
+    eprintln!("get_commits_between returning commits, len: {}", commits.len());
+
+    // reverse to obtain chronological order
+    commits.reverse();
+    Ok(commits)
+}
+
+enum Loop<E> { Break, Next, Err(E) }
+enum Void { }
+
+fn parse_paged_elems<Elem: for<'a> serde::Deserialize<'a>>(response: Response,
+                                                           mut k: impl FnMut(Elem) -> Loop<Error>)
+                                                           -> Result<Loop<Void>, Error>
+{
+    // parse the JSON into an array of the expected Elem type
+    let elems: Vec<Elem> = response.json()?;
+
+    // if `elems` is empty, then we've run out of useful pages to lookup.
+    if elems.len() == 0 { return Ok(Loop::Break); }
+
+    for elem in elems.into_iter() {
+        let act = k(elem);
+
+        // the callback will tell us if we should terminate loop early (e.g. due to matching `sha`)
+        match act {
+            Loop::Break => return Ok(Loop::Break),
+            Loop::Err(e) => return Err(e),
+            Loop::Next => continue,
+        }
+    }
+
+    // by default, we keep searching on next page from github.
+    Ok(Loop::Next)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -966,10 +966,10 @@ fn check_bounds(start: &Option<Bound>, end: &Option<Bound>) -> Result<(), Error>
         (Some(Bound::Date(start)), Some(Bound::Date(end))) if end < start => {
             bail!(
                 "end should be after start, got start: {:?} and end {:?}",
-		start,
-		end
+                start,
+                end
             );
-	},
+        },
         _ => {}
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ mod least_satisfying;
 mod repo_access;
 
 use crate::least_satisfying::{least_satisfying, Satisfies};
-use crate::repo_access::{AccessViaLocalGit, RustRepositoryAccessor};
+use crate::repo_access::{AccessViaGithub, AccessViaLocalGit, RustRepositoryAccessor};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Commit {
@@ -946,7 +946,7 @@ impl Config {
         let repo_access: Box<dyn RustRepositoryAccessor>;
         repo_access = match args.access.as_ref().map(|x|x.as_str()) {
             None | Some("checkout") => Box::new(AccessViaLocalGit),
-            Some("github") => unimplemented!(),
+            Some("github") => Box::new(AccessViaGithub),
             Some(other) => bail!("unknown access argument: {}", other),
         };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use std::path::{Path, PathBuf};
 use std::process::{self, Command, Stdio};
 use std::str::FromStr;
 
-use chrono::{Date, Duration, naive, Utc};
+use chrono::{Date, DateTime, Duration, naive, Utc};
 use dialoguer::Select;
 use failure::{bail, format_err, Fail, Error};
 use flate2::read::GzDecoder;
@@ -36,6 +36,13 @@ mod least_satisfying;
 
 use crate::least_satisfying::{least_satisfying, Satisfies};
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct Commit {
+    pub sha: String,
+    pub date: DateTime<Utc>,
+    pub summary: String,
+}
+
 /// The first commit which build artifacts are made available through the CI for
 /// bisection.
 ///
@@ -47,7 +54,7 @@ const EPOCH_COMMIT: &str = "927c55d86b0be44337f37cf5b0a76fb8ba86e06c";
 const NIGHTLY_SERVER: &str = "https://static.rust-lang.org/dist";
 const CI_SERVER: &str = "https://s3-us-west-1.amazonaws.com/rust-lang-ci2";
 
-fn get_commits(start: &str, end: &str) -> Result<Vec<git::Commit>, Error> {
+fn get_commits(start: &str, end: &str) -> Result<Vec<Commit>, Error> {
     eprintln!("fetching commits from {} to {}", start, end);
     let commits = git::get_commits_between(start, end)?;
     assert_eq!(commits.first().expect("at least one commit").sha, git::expand_commit(start)?);

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,10 +166,12 @@ struct Opts {
     script: Option<PathBuf>,
 }
 
+pub type GitDate = Date<Utc>;
+
 #[derive(Clone, Debug)]
 enum Bound {
     Commit(String),
-    Date(Date<Utc>),
+    Date(GitDate),
 }
 
 #[derive(Fail, Debug)]
@@ -235,7 +237,7 @@ struct Toolchain {
 #[derive(Clone, PartialEq, Eq, Debug)]
 enum ToolchainSpec {
     Ci { commit: String, alt: bool },
-    Nightly { date: Date<Utc> },
+    Nightly { date: GitDate },
 }
 
 impl fmt::Display for ToolchainSpec {
@@ -447,7 +449,7 @@ enum TestOutcome {
 impl Toolchain {
     /// This returns the date of the default toolchain, if it is a nightly toolchain.
     /// Returns `None` if the installed toolchain is not a nightly toolchain.
-    fn default_nightly() -> Option<Date<Utc>> {
+    fn default_nightly() -> Option<GitDate> {
         let version_meta = rustc_version::version_meta().unwrap();
 
         if let Channel::Nightly = version_meta.channel {
@@ -1160,12 +1162,12 @@ fn print_final_report(
 }
 
 struct NightlyFinderIter {
-    start_date: Date<Utc>,
-    current_date: Date<Utc>,
+    start_date: GitDate,
+    current_date: GitDate,
 }
 
 impl NightlyFinderIter {
-    fn new(start_date: Date<Utc>) -> Self {
+    fn new(start_date: GitDate) -> Self {
         Self {
             start_date,
             current_date: start_date,
@@ -1174,9 +1176,9 @@ impl NightlyFinderIter {
 }
 
 impl Iterator for NightlyFinderIter {
-    type Item = Date<Utc>;
+    type Item = GitDate;
 
-    fn next(&mut self) -> Option<Date<Utc>> {
+    fn next(&mut self) -> Option<GitDate> {
         let current_distance = self.start_date - self.current_date;
 
         let jump_length =

--- a/src/repo_access.rs
+++ b/src/repo_access.rs
@@ -1,0 +1,40 @@
+use crate::{Bound, Commit, Error, GitDate};
+
+pub(crate) trait RustRepositoryAccessor {
+    /// Maps `bound` to its associated date, looking up its commit if necessary.
+    fn bound_to_date(&self, bound: Bound) -> Result<GitDate, Error> {
+        match bound {
+            Bound::Date(date) => Ok(date),
+            Bound::Commit(ref commit_ref) =>
+                self.commit(commit_ref).map(|commit| commit.date.date()),
+        }
+    }
+
+    /// Looks up commit associated with `commit_ref`, which can be either a sha
+    /// or a more general reference like "origin/master".
+    fn commit(&self, commit_ref: &str) -> Result<Commit, Error>;
+
+    /// Looks up a series of commits ending with `end_sha`; the resulting series
+    /// should start with `start_sha`. If `start_sha` is not a predecessor of
+    /// `end_sha` in the history, then the series will cover all commits as far
+    /// back as the date associated with `start_sha`.
+    fn commits(&self, start_sha: &str, end_sha: &str) -> Result<Vec<Commit>, Error>;
+}
+
+#[path="git.rs"]
+mod git;
+
+pub(crate) struct AccessViaLocalGit;
+
+impl RustRepositoryAccessor for AccessViaLocalGit {
+    fn commit(&self, commit_ref: &str) -> Result<Commit, Error> {
+        self::git::get_commit(commit_ref)
+    }
+    fn commits(&self, start_sha: &str, end_sha: &str) -> Result<Vec<Commit>, Error> {
+        eprintln!("fetching (via local git) commits from {} to {}", start_sha, end_sha);
+        git::get_commits_between(start_sha, end_sha)
+            .map_err(|e| {
+                failure::format_err!("failed during attempt to create/access local git repository: {}", e)
+            })
+    }
+}


### PR DESCRIPTION
Adds `--access` command line flag.

There are two values current for the flag: `--access=checkout` (the original behavior, and remains the default for now) and `--access=github (the new behavior).

In the long term, we will probably want `--access=github` to be the default, but there are some refinements I think we want before we do that.

In any case, I wanted to get this code up so that it doesn't bitrot further, since it seems like there are parallel efforts that could accelerate bitrot if I don't get it up.

----

The aforementioned refinements are written out in one of the commits, but here they are again:

 1. To-do: Fallback to local checkout if the github accessor errors out

 2. To-do: Add a warning to stdout if the user runs github access without  passing an access token via GITHUB_TOKEN env var (since doing that will    hit rate limit much faster).

----

Fix #40 