### PR TITLE
Fix bug where missing end would default to "origin/master" then get compared to a sha

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -962,10 +962,11 @@ fn bisect_ci_via(
     client: &Client,
     access: &dyn RustRepositoryAccessor,
     start_sha: &str,
-    end_sha: &str)
+    end_ref: &str)
     -> Result<BisectionResult, Error>
 {
-    let commits = access.commits(start_sha, end_sha)?;
+    let end_sha = access.commit(end_ref)?.sha;
+    let commits = access.commits(start_sha, &end_sha)?;
 
     assert_eq!(commits.last().expect("at least one commit").sha, end_sha);
 


### PR DESCRIPTION
Otherwise you get this:

```
$ cargo-bisect-rustc --prompt --test-dir=foo --start e768d6f0bc6
bisecting ci builds
starting at e768d6f0bc6, ending at origin/master
fetching (via local git) commits from e768d6f0bc6 to origin/master
opening existing repository at "rust.git"
refreshing repository
looking up first commit
looking up second commit
checking that commits are by bors and thus have ci artifacts...
finding bors merge commits
found 21 bors merge commits in the specified range
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `"76b11980ad416c3ad6143504c2277757ecacf9b5"`,
 right: `"origin/master"`', /home/dillona/.cargo/registry/src/github.com-1ecc6299db9ec823/cargo-bisect-rustc-0.4.0/src/main.rs:970:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```