### PR TITLE
Add ANSI color support and improved standard stream formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,7 @@ name = "cargo-bisect-rustc"
 version = "0.4.1"
 dependencies = [
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "colored 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "dialoguer 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -205,6 +206,16 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "colored"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1719,6 +1730,7 @@ dependencies = [
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum clicolors-control 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90082ee5dcdd64dc4e9e0d37fbf3ee325419e39c0092191e0393df65518f741e"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum colored 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
 "checksum console 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "45e0f3986890b3acbc782009e2629dfe2baa430ac091519ce3be26164a2ae6c0"
 "checksum constant_time_eq 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "995a44c877f9212528ccc74b21a232f66ad69001e40ede5bcee2ac9ef2657120"
 "checksum core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ tee = "0.1"
 tempdir = "0.3.7"
 xz2 = "0.1.6"
 chrono = "0.4.11"
+colored="1.9"
 
 [dev-dependencies]
 quickcheck = "0.9.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use std::process::{self, Command};
 use std::str::FromStr;
 
 use chrono::{Date, DateTime, Duration, Utc};
+use colored::*;
 use failure::{bail, format_err, Fail, Error};
 use log::debug;
 use reqwest::blocking::Client;
@@ -634,7 +635,13 @@ fn print_results(cfg: &Config, client: &Client, bisection_result: &BisectionResu
         }
     }
 
-    eprintln!("regression in {}", toolchains[*found]);
+    let tc_found = format!("Regression in {}", toolchains[*found]);
+    eprintln!("");
+    eprintln!("");
+    eprintln!("{}", "*".repeat(80).dimmed().bold());
+    eprintln!("{}", tc_found.red());
+    eprintln!("{}", "*".repeat(80).dimmed().bold());
+    eprintln!("");
 }
 
 fn print_final_report(
@@ -653,14 +660,16 @@ fn print_final_report(
         ..
     } = ci_bisection_result;
 
-    eprintln!("");
-    eprintln!("");
-
-    eprintln!("==================================================================================");
-    eprintln!("= Please open an issue on Rust's github repository                               =");
-    eprintln!("= https://github.com/rust-lang/rust/issues/new                                   =");
-    eprintln!("= Below you will find a text that would serve as a starting point of your report =");
-    eprintln!("==================================================================================");
+    #[rustfmt::skip]
+    eprintln!("{}", "==================================================================================".dimmed());
+    #[rustfmt::skip]
+    eprintln!("{}", "= Please open an issue on Rust's github repository                               =".dimmed());
+    #[rustfmt::skip]
+    eprintln!("{}", "= https://github.com/rust-lang/rust/issues/new                                   =".dimmed());
+    #[rustfmt::skip]
+    eprintln!("{}", "= Below you will find a text that would serve as a starting point of your report =".dimmed());
+    #[rustfmt::skip]
+    eprintln!("{}", "==================================================================================".dimmed());
 
     eprintln!("");
 
@@ -1071,6 +1080,7 @@ fn bisect_ci_in_commits(
     }
 
     eprintln!("validated commits found, specifying toolchains");
+    eprintln!("");
 
     let toolchains = commits
         .into_iter()
@@ -1142,7 +1152,8 @@ fn main() {
         match err.downcast::<ExitError>() {
             Ok(ExitError(code)) => process::exit(code),
             Err(err) => {
-                eprintln!("ERROR: {}", err);
+                let error_str = "ERROR:".red().bold();
+                eprintln!("{} {}", error_str, err);
                 process::exit(1);
             }
         }

--- a/src/toolchains.rs
+++ b/src/toolchains.rs
@@ -12,6 +12,7 @@ use std::path::{Path, PathBuf};
 use std::process::{self, Command, Stdio};
 
 use chrono::{Date, naive, Utc};
+use colored::*;
 use dialoguer::Select;
 use failure::{Fail, Error};
 use flate2::read::GzDecoder;
@@ -139,7 +140,8 @@ impl Toolchain {
         client: &Client,
         dl_params: &DownloadParams,
     ) -> Result<(), InstallError> {
-        eprintln!("installing {}", self);
+        let tc_stdstream_str = format!("{}", self);
+        eprintln!("installing {}", tc_stdstream_str.green());
         let tmpdir = TempDir::new_in(&dl_params.tmp_dir, &self.rustup_name())
             .map_err(InstallError::TempDir)?;
         let dest = dl_params.install_dir.join(self.rustup_name());


### PR DESCRIPTION
The output from the tool is lengthy and it is difficult to view relevant information in the wall of text that streams by during execution. 

This PR adds ANSI escape code color support and a few std stream formatting improvements.

Nightly bisections:

<img width="933" alt="2020-05-02_23-56-01" src="https://user-images.githubusercontent.com/4249591/80898493-069a0780-8cd2-11ea-8405-0c71c8130c1a.png">

Commit level bisections:

<img width="936" alt="2020-05-02_23-56-30" src="https://user-images.githubusercontent.com/4249591/80898494-1285c980-8cd2-11ea-809a-e994fb821f80.png">

The final report and instructions for reporting:

<img width="936" alt="2020-05-02_23-57-00" src="https://user-images.githubusercontent.com/4249591/80898497-23363f80-8cd2-11ea-895c-2128725f7914.png">

Errors:

<img width="935" alt="2020-05-02_23-59-10" src="https://user-images.githubusercontent.com/4249591/80898499-2af5e400-8cd2-11ea-96b4-148339e74f87.png">
