### PR TITLE
Update final report: new data, elimination of extra Markdown formatting, updated instructions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -699,9 +699,6 @@ fn print_final_report(
 
     eprintln!("");
 
-    eprintln!("# Regression found in the compiler");
-    eprintln!("");
-
     let (start, end) = searched_range(cfg, nightly_toolchains);
 
     eprintln!("searched nightlies: from {} to {}", start, end);
@@ -719,24 +716,30 @@ fn print_final_report(
         ci_toolchains[*ci_found],
     );
 
-    eprintln!("source code: URL OF A REPOSITORY THAT REPRODUCES THE ERROR");
+    eprintln!("");
+    eprintln!("<details>");
+    eprintln!(
+        "<summary>bisected with <a href='{}'>cargo-bisect-rustc</a> v{}</summary>",
+        env!("CARGO_PKG_REPOSITORY"),
+        env!("CARGO_PKG_VERSION"),
+    );
+    eprintln!("");
+    eprintln!("");
+    if let Some(host) = option_env!("HOST") {
+        eprintln!("Host triple: {}", host);
+    }
 
-    eprintln!("");
-
-    eprintln!("## Instructions");
-    eprintln!("");
-    eprintln!("Please give the steps for how to build your repository (platform, system dependencies, etc.)");
-
-    eprintln!("## Error");
-    eprintln!("");
-    eprintln!("<details><summary>COLLAPSIBLE ERROR STACKTRACE</summary>");
-    eprintln!("<p>");
-    eprintln!("");
+    eprintln!("Reproduce with:");
     eprintln!("```bash");
-    eprintln!("Paste the error the compiler is giving");
-    eprintln!("```");
+    eprint!("cargo bisect-rustc ");
+    for (index, arg) in env::args_os().enumerate() {
+        if index > 1 {
+            eprint!("{} ", arg.to_string_lossy());
+        }
+    }
     eprintln!("");
-    eprintln!("</p></details>");
+    eprintln!("```");
+    eprintln!("</details>");
 }
 
 struct NightlyFinderIter {

--- a/src/main.rs
+++ b/src/main.rs
@@ -689,11 +689,13 @@ fn print_final_report(
     #[rustfmt::skip]
     eprintln!("{}", "==================================================================================".dimmed());
     #[rustfmt::skip]
-    eprintln!("{}", "= Please open an issue on Rust's github repository                               =".dimmed());
+    eprintln!("{}", "= Please file this regression report on the rust-lang/rust GitHub repository     =".dimmed());
     #[rustfmt::skip]
-    eprintln!("{}", "= https://github.com/rust-lang/rust/issues/new                                   =".dimmed());
+    eprintln!("{}", "=        New issue: https://github.com/rust-lang/rust/issues/new                 =".dimmed());
     #[rustfmt::skip]
-    eprintln!("{}", "= Below you will find a text that would serve as a starting point of your report =".dimmed());
+    eprintln!("{}", "=     Known issues: https://github.com/rust-lang/rust/issues                     =".dimmed());
+    #[rustfmt::skip]
+    eprintln!("{}", "= Copy and paste the text below into the issue report thread.  Thanks!           =".dimmed());
     #[rustfmt::skip]
     eprintln!("{}", "==================================================================================".dimmed());
 


### PR DESCRIPTION
This PR is followup work after [a recent conversation](https://github.com/rust-lang/cargo-bisect-rustc/pull/79#issuecomment-623119788) with @Mark-Simulacrum.

The changes include:

- updated regression report submission instructions
- removal of (likely) unnecessary Markdown formatting that is not typically pasted into rust-lang/rust IR threads by those who participate in the bisection diagnostics
- addition of the cargo-bisect-rustc version that was used for bisection and link to this repository
- addition of the host triple during bisect-rustc execution
- addition of the command line args that can be used to reproduce the cargo-bisect-rustc report

### Updated regression reporting instructions

```
==================================================================================
= Please file this regression report on the rust-lang/rust GitHub repository     =
=        New issue: https://github.com/rust-lang/rust/issues/new                 =
=     Known issues: https://github.com/rust-lang/rust/issues                     =
= Copy and paste the text below into the issue report thread.  Thanks!           =
==================================================================================
```

### New copy/paste report for rust-lang/rust threads

searched nightlies: from nightly-2020-04-07 to nightly-2020-04-08
regressed nightly: nightly-2020-04-08
searched commits: from https://github.com/rust-lang/rust/commit/6dee5f1126dfd5c9314ee5ae9d9eb010e35ef257 to https://github.com/rust-lang/rust/commit/42abbd8878d3b67238f3611b0587c704ba94f39c
regressed commit: https://github.com/rust-lang/rust/commit/209b2be09fcaff937480d1fbbe8b31646e361c7a

<details>
<summary>bisected with <a href='https://github.com/rust-lang/cargo-bisect-rustc'>cargo-bisect-rustc</a> v0.5.0</summary>


Host triple: x86_64-apple-darwin
Reproduce with:
```bash
cargo bisect-rustc --start=2020-04-07 --end=2020-04-08 --access=github
```
</details>

