### PR TITLE
Add GH Actions CI badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Cargo Bisection
 
+[![GNU/Linux CI](https://github.com/rust-lang/cargo-bisect-rustc/workflows/GNU/Linux%20CI/badge.svg)](https://github.com/rust-lang/cargo-bisect-rustc/actions?query=workflow%3A%22GNU%2FLinux+CI%22)
+[![macOS CI](https://github.com/rust-lang/cargo-bisect-rustc/workflows/macOS%20CI/badge.svg)](https://github.com/rust-lang/cargo-bisect-rustc/actions?query=workflow%3A%22macOS+CI%22)
+[![Windows CI](https://github.com/rust-lang/cargo-bisect-rustc/workflows/Windows%20CI/badge.svg)](https://github.com/rust-lang/cargo-bisect-rustc/actions?query=workflow%3A%22Windows+CI%22)
+
 This tool bisects either Rust nightlies or CI artifacts.
 
 [**Tutorial**](TUTORIAL.md)


### PR DESCRIPTION
Adds badges for each of the platform CI workflows with links to the filtered action history