### PR TITLE
Convert to default installation of cargo and replace `--with-cargo` option with `--without-cargo` option

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -151,6 +151,12 @@ struct Opts {
         parse(from_os_str)
     )]
     script: Option<PathBuf>,
+
+    #[structopt(
+        long = "without-cargo",
+        help = "Do not install cargo [default: install cargo]"
+    )]
+    without_cargo: bool,
 }
 
 pub type GitDate = Date<Utc>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,12 +93,6 @@ struct Opts {
     )]
     preserve_target: bool,
 
-    #[structopt(
-        long = "with-cargo",
-        help = "Download cargo [default: installed cargo]"
-    )]
-    with_cargo: bool,
-
     #[structopt(long = "with-src", help = "Download rust-src [default: no download]")]
     with_src: bool,
 

--- a/src/toolchains.rs
+++ b/src/toolchains.rs
@@ -231,20 +231,21 @@ impl Toolchain {
             .map_err(InstallError::Download)?;
         }
 
-        // download nightly cargo by default
-        // this behavior was changed from an
-        // optional feature with the `--with-cargo`
-        // flag as of v0.6.0
+        // download cargo by default
+        // deactivate with the `--without-cargo` flag
+        // this default behavior was changed as of v0.6.0
         // see: https://github.com/rust-lang/cargo-bisect-rustc/issues/81
-        let filename = format!("cargo-nightly-{}", self.host);
-        download_tarball(
-            &client,
-            &format!("cargo for {}", self.host),
-            &format!("{}/{}/{}.tar", dl_params.url_prefix, location, filename,),
-            Some(&PathBuf::from(&filename).join("cargo")),
-            tmpdir.path(),
-        )
-        .map_err(InstallError::Download)?;
+        if !dl_params.without_cargo {
+            let filename = format!("cargo-nightly-{}", self.host);
+            download_tarball(
+                &client,
+                &format!("cargo for {}", self.host),
+                &format!("{}/{}/{}.tar", dl_params.url_prefix, location, filename,),
+                Some(&PathBuf::from(&filename).join("cargo")),
+                tmpdir.path(),
+            )
+            .map_err(InstallError::Download)?;
+        }
 
         if dl_params.install_src {
             let filename = "rust-src-nightly";
@@ -411,6 +412,7 @@ pub(crate) struct DownloadParams {
     tmp_dir: PathBuf,
     install_dir: PathBuf,
     install_src: bool,
+    without_cargo: bool,
     force_install: bool,
 }
 
@@ -435,6 +437,7 @@ impl DownloadParams {
             tmp_dir: cfg.rustup_tmp_path.clone(),
             install_dir: cfg.toolchains_path.clone(),
             install_src: cfg.args.with_src,
+            without_cargo: cfg.args.without_cargo,
             force_install: cfg.args.force_install,
         }
     }

--- a/src/toolchains.rs
+++ b/src/toolchains.rs
@@ -231,17 +231,20 @@ impl Toolchain {
             .map_err(InstallError::Download)?;
         }
 
-        if dl_params.install_cargo {
-            let filename = format!("cargo-nightly-{}", self.host);
-            download_tarball(
-                &client,
-                &format!("cargo for {}", self.host),
-                &format!("{}/{}/{}.tar", dl_params.url_prefix, location, filename,),
-                Some(&PathBuf::from(&filename).join("cargo")),
-                tmpdir.path(),
-            )
-            .map_err(InstallError::Download)?;
-        }
+        // download nightly cargo by default
+        // this behavior was changed from an
+        // optional feature with the `--with-cargo`
+        // flag as of v0.6.0
+        // see: https://github.com/rust-lang/cargo-bisect-rustc/issues/81
+        let filename = format!("cargo-nightly-{}", self.host);
+        download_tarball(
+            &client,
+            &format!("cargo for {}", self.host),
+            &format!("{}/{}/{}.tar", dl_params.url_prefix, location, filename,),
+            Some(&PathBuf::from(&filename).join("cargo")),
+            tmpdir.path(),
+        )
+        .map_err(InstallError::Download)?;
 
         if dl_params.install_src {
             let filename = "rust-src-nightly";
@@ -407,7 +410,6 @@ pub(crate) struct DownloadParams {
     url_prefix: String,
     tmp_dir: PathBuf,
     install_dir: PathBuf,
-    install_cargo: bool,
     install_src: bool,
     force_install: bool,
 }
@@ -432,7 +434,6 @@ impl DownloadParams {
             url_prefix,
             tmp_dir: cfg.rustup_tmp_path.clone(),
             install_dir: cfg.toolchains_path.clone(),
-            install_cargo: cfg.args.with_cargo,
             install_src: cfg.args.with_src,
             force_install: cfg.args.force_install,
         }


### PR DESCRIPTION
Closes #81 

Also see the discussion in https://rust-lang.zulipchat.com/#narrow/stream/217417-t-compiler.2Fcargo-bisect-rustc/topic/unrecognized.20option.20json

This PR converts the `--with-cargo` optional behavior to default behavior to address  `Unrecognized option: 'json'` errors in tests as bisection proceeds back in time past a defined date (I believe that this is ~ July 2019'ish era).  The current default leads to incorrect automated detection of the regression commit due to this error.  These changes also remove the `--with-cargo` option.

Edit: @spastorino recommended the addition of the `--without-cargo` flag to disable the cargo install in https://github.com/rust-lang/cargo-bisect-rustc/pull/98#issuecomment-644284958.  This change was added in https://github.com/rust-lang/cargo-bisect-rustc/commit/2b7088c7f28fbf2dda7023a8fc30c092ab7764a1