### PR TITLE
Add rustc-dev component option

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -96,6 +96,9 @@ struct Opts {
     #[structopt(long = "with-src", help = "Download rust-src [default: no download]")]
     with_src: bool,
 
+    #[structopt(long = "with-dev", help = "Download rustc-dev [default: no download]")]
+    with_dev: bool,
+
     #[structopt(
         long = "test-dir",
         help = "Root directory for tests",


### PR DESCRIPTION
Fixes https://github.com/rust-lang/cargo-bisect-rustc/issues/100
I added a `--with-dev` option to download rustc-dev.
Because of https://github.com/rust-lang/rust/issues/72594 I also install llvm-tools together with rustc-dev