### PR TITLE
note that specified commits should be from the master branch

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -83,7 +83,7 @@ pub fn get_commits_between(first_commit: &str, last_commit: &str) -> Result<Vec<
     let assert_by_bors = |c: &Git2Commit<'_>| -> Result<(), Error> {
         match c.author().name() {
             Some("bors") => Ok(()),
-            Some(author) => bail!("Expected author {} to be bors for {}", author, c.id()),
+            Some(author) => bail!("Expected author {} to be bors for {}.\n Make sure specified commits are on the master branch!", author, c.id()),
             None => bail!("No author for {}", c.id()),
         }
     };


### PR DESCRIPTION
While trying to get cbr working I ran into the ominous
"Expected author Brian Anderson to be bors for beb9a0dfc52ebda4f8db4e5d439e08e4f3a43a39"
error.

The problem seems to be that all commits are expected to be found in the master branch, so simply feeding in a git tag commit or
something of a beta/stable branch does not work.

Tweak error message to reflect that.

cc #27