### PR TITLE
Remove copyright banner just like rustc repo

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,10 +1,3 @@
-// Copyright 2018 The Rust Project Developers
-//
-// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
-// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
-// http://opensource.org/licenses/MIT>, at your option. This file may not be
-// copied, modified, or distributed except according to those terms.
-
 use std::env;
 
 fn main() {

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,10 +1,3 @@
-// Copyright 2018 The Rust Project Developers
-//
-// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
-// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
-// http://opensource.org/licenses/MIT>, at your option. This file may not be
-// copied, modified, or distributed except according to those terms.
-
 //! Get git commits with help of the libgit2 library
 
 const RUST_SRC_URL: &str = "https://github.com/rust-lang/rust";

--- a/src/least_satisfying.rs
+++ b/src/least_satisfying.rs
@@ -1,10 +1,3 @@
-// Copyright 2018 The Rust Project Developers
-//
-// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
-// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
-// http://opensource.org/licenses/MIT>, at your option. This file may not be
-// copied, modified, or distributed except according to those terms.
-
 use std::collections::BTreeMap;
 use std::fmt;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,3 @@
-// Copyright 2018 The Rust Project Developers
-//
-// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
-// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
-// http://opensource.org/licenses/MIT>, at your option. This file may not be
-// copied, modified, or distributed except according to those terms.
-
 use std::env;
 use std::ffi::OsString;
 use std::fmt;

--- a/src/toolchains.rs
+++ b/src/toolchains.rs
@@ -1,9 +1,3 @@
-// Copyright 2018 The Rust Project Developers
-//
-// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
-// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
-// http://opensource.org/licenses/MIT>, at your option. This file may not be
-// copied, modified, or distributed except according to those terms.
 use std::fmt;
 use std::fs;
 use std::io::{self, Read, Write};


### PR DESCRIPTION
Doing the same thing like https://github.com/rust-lang/rust/pull/57108 