### PR TITLE
Anonymously fetch from upstream rust repo

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -38,9 +38,7 @@ fn get_repo() -> Result<Repository, Error> {
         let repo = Repository::open(repo)?;
         {
             eprintln!("refreshing repository");
-            let mut remote = repo
-                .find_remote("origin")
-                .or_else(|_| repo.remote_anonymous("origin"))?;
+            let mut remote = repo.remote_anonymous(RUST_SRC_URL)?;
             remote.fetch(&["master"], None, None)?;
         }
         Ok(repo)

--- a/src/repo_access.rs
+++ b/src/repo_access.rs
@@ -37,6 +37,11 @@ impl RustRepositoryAccessor for AccessViaLocalGit {
         self::git::get_commit(commit_ref)
     }
     fn commits(&self, start_sha: &str, end_sha: &str) -> Result<Vec<Commit>, Error> {
+        let end_sha = if end_sha == "origin/master" {
+            "FETCH_HEAD"
+        } else {
+            end_sha
+        };
         eprintln!(
             "fetching (via local git) commits from {} to {}",
             start_sha, end_sha


### PR DESCRIPTION
`origin` or `upstream` are commonly used remote names. 
However they aren't always the right remote with URL points to rustc URL.
Their URLs could contain SSH aliases that we don't resolve.

Let's fetch anonymously from https://github.com/rust-lang/rust and use FETCH_HEAD
to refer to it.