### PR TITLE
Verify that --test-dir is a directory

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -442,6 +442,13 @@ impl Config {
             );
         }
 
+        if !args.test_dir.is_dir() {
+            bail!(
+                "`{}` is not a directory. Please make sure --test-dir is correct",
+                args.test_dir.display()
+            );
+        }
+
         let is_commit = match (args.start.clone(), args.end.clone()) {
             (Some(Bound::Commit(_)), Some(Bound::Commit(_)))
             | (None, Some(Bound::Commit(_)))


### PR DESCRIPTION
While trying to bisect an issue I copied and pasted `cargo bisect-rustc --test-dir=foo --start=2018-05-07 --end=2018-08-04` from TUTORIAL.md and just changed the `--start` and `--end` versions.

<details>
<summary>Running the command lead to this panic</summary>

thread 'main' panicked at 'failed to run "cargo" "+bisector-nightly-2020-08-17-x86_64-unknown-linux-gnu" "test": Os { code: 2, kind: NotFound, message: "No such file or directory" }', /home/paolo/.cargo/registry/src/github.com-1ecc6299db9ec823/cargo-bisect-rustc-0.5.2/src/toolchains.rs:335:17
stack backtrace:
   0:     0x55fa36cc7da0 - std::backtrace_rs::backtrace::libunwind::trace::h14e81b0c16b543a7
                               at /rustc/9b4154193e8471f36b1a9e781f1ef7d492fc6a6c/library/std/src/../../backtrace/src/backtrace/libunwind.rs:96
   1:     0x55fa36cc7da0 - std::backtrace_rs::backtrace::trace_unsynchronized::hc9e39e172835ff32
                               at /rustc/9b4154193e8471f36b1a9e781f1ef7d492fc6a6c/library/std/src/../../backtrace/src/backtrace/mod.rs:66
   2:     0x55fa36cc7da0 - std::sys_common::backtrace::_print_fmt::h31994df1c8c77b8f
                               at /rustc/9b4154193e8471f36b1a9e781f1ef7d492fc6a6c/library/std/src/sys_common/backtrace.rs:79
   3:     0x55fa36cc7da0 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::he74e98acff43ec99
                               at /rustc/9b4154193e8471f36b1a9e781f1ef7d492fc6a6c/library/std/src/sys_common/backtrace.rs:58
   4:     0x55fa36cef82c - core::fmt::write::h1857a60b204f1b6a
                               at /rustc/9b4154193e8471f36b1a9e781f1ef7d492fc6a6c/library/core/src/fmt/mod.rs:1080
   5:     0x55fa36cc1147 - std::io::Write::write_fmt::hea6289e6649ff508
                               at /rustc/9b4154193e8471f36b1a9e781f1ef7d492fc6a6c/library/std/src/io/mod.rs:1517
   6:     0x55fa36cca690 - std::sys_common::backtrace::_print::h8cc65937fea24014
                               at /rustc/9b4154193e8471f36b1a9e781f1ef7d492fc6a6c/library/std/src/sys_common/backtrace.rs:61
   7:     0x55fa36cca690 - std::sys_common::backtrace::print::hff6a0ebb96535e34
                               at /rustc/9b4154193e8471f36b1a9e781f1ef7d492fc6a6c/library/std/src/sys_common/backtrace.rs:48
   8:     0x55fa36cca690 - std::panicking::default_hook::{{closure}}::h71b9700c5dda1b1d
                               at /rustc/9b4154193e8471f36b1a9e781f1ef7d492fc6a6c/library/std/src/panicking.rs:208
   9:     0x55fa36cca3dc - std::panicking::default_hook::h0c46e634c06c69b6
                               at /rustc/9b4154193e8471f36b1a9e781f1ef7d492fc6a6c/library/std/src/panicking.rs:227
  10:     0x55fa36ccacf3 - std::panicking::rust_panic_with_hook::he52576a0c2093334
                               at /rustc/9b4154193e8471f36b1a9e781f1ef7d492fc6a6c/library/std/src/panicking.rs:577
  11:     0x55fa36cca8c9 - std::panicking::begin_panic_handler::{{closure}}::h411c800b810762b2
                               at /rustc/9b4154193e8471f36b1a9e781f1ef7d492fc6a6c/library/std/src/panicking.rs:484
  12:     0x55fa36cc822c - std::sys_common::backtrace::__rust_end_short_backtrace::ha657a272019e6aad
                               at /rustc/9b4154193e8471f36b1a9e781f1ef7d492fc6a6c/library/std/src/sys_common/backtrace.rs:153
  13:     0x55fa36cca889 - rust_begin_unwind
                               at /rustc/9b4154193e8471f36b1a9e781f1ef7d492fc6a6c/library/std/src/panicking.rs:483
  14:     0x55fa36cca83b - std::panicking::begin_panic_fmt::h8679424505ca4cf5
                               at /rustc/9b4154193e8471f36b1a9e781f1ef7d492fc6a6c/library/std/src/panicking.rs:437
  15:     0x55fa36922a19 - cargo_bisect_rustc::toolchains::Toolchain::run_test::h7da5ba6990a4d173
  16:     0x55fa36922e51 - cargo_bisect_rustc::toolchains::Toolchain::test::hbfd4b70a58cb3708
  17:     0x55fa36900cfd - cargo_bisect_rustc::install_and_test::h28aa31dd8b5e3d3c
  18:     0x55fa368fd5b1 - cargo_bisect_rustc::bisect::h51353250e51c38cb
  19:     0x55fa368fb883 - cargo_bisect_rustc::run::h0d1722969490961d
  20:     0x55fa3690238d - cargo_bisect_rustc::main::h7978755c698f5942
  21:     0x55fa3690f4d3 - std::sys_common::backtrace::__rust_begin_short_backtrace::hedff8ab5fb9a5aeb
  22:     0x55fa3690f729 - std::rt::lang_start::{{closure}}::h6d8274c2267b118c
  23:     0x55fa36ccb1c1 - core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once::h009d20b8a620bf60
                               at /rustc/9b4154193e8471f36b1a9e781f1ef7d492fc6a6c/library/core/src/ops/function.rs:259
  24:     0x55fa36ccb1c1 - std::panicking::try::do_call::h09431c39e2107c90
                               at /rustc/9b4154193e8471f36b1a9e781f1ef7d492fc6a6c/library/std/src/panicking.rs:381
  25:     0x55fa36ccb1c1 - std::panicking::try::he27cf60b958af343
                               at /rustc/9b4154193e8471f36b1a9e781f1ef7d492fc6a6c/library/std/src/panicking.rs:345
  26:     0x55fa36ccb1c1 - std::panic::catch_unwind::h7b646b0041dc5591
                               at /rustc/9b4154193e8471f36b1a9e781f1ef7d492fc6a6c/library/std/src/panic.rs:382
  27:     0x55fa36ccb1c1 - std::rt::lang_start_internal::hdad6c98af1e4747e
                               at /rustc/9b4154193e8471f36b1a9e781f1ef7d492fc6a6c/library/std/src/rt.rs:51
  28:     0x55fa369024b2 - main
  29:     0x7f6f113410b3 - __libc_start_main
  30:     0x55fa368f30fe - _start
  31:                0x0 - <unknown>
</details>

At first glance it wasn't immediately obvious to me what had happened. I thought something broke with cargo.

Looking back on this it was a very silly mistake, but seeing how other folders are [already getting checked](https://github.com/rust-lang/cargo-bisect-rustc/blob/fb41a963c1a5bfa3f0a752817289cd28403384ff/src/main.rs#L438-L443), it probably makes sense to also check this one!?