### PR TITLE
Fix an off-by-one error when calculating current nightly date in local

### DIFF
--- a/src/toolchains.rs
+++ b/src/toolchains.rs
@@ -100,10 +100,10 @@ impl Toolchain {
                         let month = cap.get(2)?.as_str().parse::<u32>().ok()?;
                         let day = cap.get(3)?.as_str().parse::<u32>().ok()?;
 
-                        return Some(Date::from_utc(
-                            naive::NaiveDate::from_ymd(year, month, day),
-                            Utc,
-                        ));
+                        // rustc commit date is off-by-one.
+                        let date = naive::NaiveDate::from_ymd(year, month, day).succ();
+
+                        return Some(Date::from_utc(date, Utc));
                     }
                 }
             }


### PR DESCRIPTION
This should fix #112.
