### PR TITLE
Calculate current nightly date only once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,7 @@ dependencies = [
  "git2",
  "home",
  "log",
+ "once_cell",
  "pbr",
  "quickcheck",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ tempdir = "0.3.7"
 xz2 = "0.1.6"
 chrono = "0.4.11"
 colored = "2"
+once_cell = "1.4.1"
 
 [dev-dependencies]
 quickcheck = "0.9.2"


### PR DESCRIPTION
This function (`default_nightly`) is hot and called repeatedly.
It also calls external rustc and compiles a regex.