### PR TITLE
Use git CLI to fetch a repo.

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -38,6 +38,7 @@ fn get_repo() -> Result<Repository, Error> {
         // This uses the CLI because libgit2 is quite slow to fetch a large repository.
         let status = std::process::Command::new("git")
             .arg("fetch")
+            .arg(RUST_SRC_URL)
             .current_dir(repo)
             .status()
             .context(format!(


### PR DESCRIPTION
This changes the git fetch of the rust-lang/rust repo to use the `git` CLI command instead of libgit2. This is because libgit2 has some performance issues with large repos. On my system, a fetch that is not particularly old takes about 4 minutes with libgit2, whereas with the git CLI it takes about 2 seconds.