### PR TITLE
Add support for git tags in `--start` and `--end`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -132,10 +132,18 @@ struct Opts {
     )]
     command_args: Vec<OsString>,
 
-    #[structopt(long = "start", help = "Left bound for search (*without* regression)")]
+    #[structopt(
+        long = "start",
+        help = "Left bound for search (*without* regression). You can use \
+a date (YYYY-MM-DD), git tag name (e.g. 1.58.0) or git commit SHA."
+    )]
     start: Option<Bound>,
 
-    #[structopt(long = "end", help = "Right bound for search (*with* regression)")]
+    #[structopt(
+        long = "end",
+        help = "Right bound for search (*with* regression). You can use \
+a date (YYYY-MM-DD), git tag name (e.g. 1.58.0) or git commit SHA."
+    )]
     end: Option<Bound>,
 
     #[structopt(long = "by-commit", help = "Bisect via commit artifacts")]


### PR DESCRIPTION
First I tried to add new `Bound` (`Version`), but that required a lot of changes in the code.

I think that just adding support for arbitrary tags is more general and should hopefully work out of the box. I changed the GH resolver to use the `compare` API, which allows us to get commit information together with `merge-base` ancestor.