### PR TITLE
Enable lto and stripping in release mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ repository = "https://github.com/rust-lang/cargo-bisect-rustc"
 version = "0.6.3"
 edition = "2021"
 
+[profile.release]
+strip = "symbols"
+lto = "fat"
+
 [dependencies]
 dialoguer = { version = "0.10.1", default-features = false }
 home = "0.5"


### PR DESCRIPTION
Reduces the size of the resulting binary from 10.5 MiB to 3.7 MiB.

For reference:
strip-only = 5.1 MiB
lto-only   = 6.3 MiB