### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 20
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Dependabot will check for updatable dependencies and create PRs to update the relevant files.

The cargo section will monitor Cargo.{toml,lock} while the github-actions section monitors any
workflow files in `.github/workflows`. Both sections are set to update on a weekly basis.

@oli-obk This is in response to your comment [here](https://github.com/rust-lang/cargo-bisect-rustc/pull/155#issuecomment-1135471781) about checking for dependency updates in a cronjob.