### PR TITLE
Fix verbose short flag.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -130,7 +130,7 @@ struct Opts {
     )]
     timeout: Option<usize>,
 
-    #[clap(long = "verbose", parse(from_occurrences))]
+    #[clap(short, long = "verbose", parse(from_occurrences))]
     verbosity: usize,
 
     #[clap(

--- a/tests/cmd/h.stdout
+++ b/tests/cmd/h.stdout
@@ -32,8 +32,8 @@ OPTIONS:
                                     hangs)
         --target <TARGET>           Cross-compilation target platform
         --test-dir <TEST_DIR>       Root directory for tests [default: .]
+    -v, --verbose                   
     -V, --version                   Print version information
-        --verbose                   
         --with-dev                  Download rustc-dev [default: no download]
         --with-src                  Download rust-src [default: no download]
         --without-cargo             Do not install cargo [default: install cargo]

--- a/tests/cmd/help.stdout
+++ b/tests/cmd/help.stdout
@@ -32,8 +32,8 @@ OPTIONS:
                                     hangs)
         --target <TARGET>           Cross-compilation target platform
         --test-dir <TEST_DIR>       Root directory for tests [default: .]
+    -v, --verbose                   
     -V, --version                   Print version information
-        --verbose                   
         --with-dev                  Download rustc-dev [default: no download]
         --with-src                  Download rust-src [default: no download]
         --without-cargo             Do not install cargo [default: install cargo]


### PR DESCRIPTION
It looks like 4ce07c8351f1e9bcea7a54d7d0c83cf614f43a30 (https://github.com/rust-lang/cargo-bisect-rustc/pull/152) inadvertently removed the `-v` short flag for `--verbose`. This adds it back.