### PR TITLE
Report an estimate of remaining steps.

### DIFF
--- a/src/least_satisfying.rs
+++ b/src/least_satisfying.rs
@@ -4,10 +4,14 @@ use std::fmt;
 pub fn least_satisfying<T, P>(slice: &[T], mut predicate: P) -> usize
 where
     T: fmt::Display + fmt::Debug,
-    P: FnMut(&T) -> Satisfies,
+    P: FnMut(&T, usize, usize) -> Satisfies,
 {
     let mut cache = BTreeMap::new();
-    let mut predicate = |idx: usize| *cache.entry(idx).or_insert_with(|| predicate(&slice[idx]));
+    let mut predicate = |idx: usize, remaining, estimate| {
+        *cache
+            .entry(idx)
+            .or_insert_with(|| predicate(&slice[idx], remaining, estimate))
+    };
     let mut unknown_ranges: Vec<(usize, usize)> = Vec::new();
     // presume that the slice starts with a no
     // this should be tested before call
@@ -40,7 +44,11 @@ where
             }
         }
 
-        let r = predicate(next);
+        let mut range = lm_yes - rm_no + 1;
+        // FIXME: This does not consider unknown_ranges.
+        let mut remaining = range / 2;
+        let estimate = estimate_steps(range);
+        let r = predicate(next, remaining, estimate);
         match r {
             Satisfies::Yes => {
                 lm_yes = next;
@@ -52,12 +60,20 @@ where
             }
             Satisfies::Unknown => {
                 let mut left = next;
-                while left > 0 && predicate(left) == Satisfies::Unknown {
+                while left > 0
+                    && predicate(left, remaining, estimate_steps(range)) == Satisfies::Unknown
+                {
                     left -= 1;
+                    remaining = remaining.saturating_sub(1);
+                    range = range.saturating_sub(1);
                 }
                 let mut right = next;
-                while right + 1 < slice.len() && predicate(right) == Satisfies::Unknown {
+                while right + 1 < slice.len()
+                    && predicate(right, remaining, estimate_steps(range)) == Satisfies::Unknown
+                {
                     right += 1;
+                    remaining = remaining.saturating_sub(1);
+                    range = range.saturating_sub(1);
                 }
                 unknown_ranges.push((left + 1, right - 1));
                 next = left;
@@ -66,10 +82,33 @@ where
     }
 }
 
+fn estimate_steps(range: usize) -> usize {
+    // Replace with int_log when it is stabilized.
+    let log2 = |mut n| {
+        let mut r = 0;
+        while n > 1 {
+            r += 1;
+            n >>= 1;
+        }
+        r
+    };
+    if range < 3 {
+        return 0;
+    }
+    let n = log2(range);
+    let e = 1 << n;
+    let x = range - e;
+    if e < 3 * x {
+        n
+    } else {
+        n - 1
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::Satisfies::{No, Unknown, Yes};
-    use super::{least_satisfying, Satisfies};
+    use super::{estimate_steps, least_satisfying, Satisfies};
     use quickcheck::{QuickCheck, TestResult};
 
     fn prop(xs: Vec<Option<bool>>) -> TestResult {
@@ -89,7 +128,7 @@ mod tests {
             }
         }
 
-        let res = least_satisfying(&satisfies_v, |i| *i);
+        let res = least_satisfying(&satisfies_v, |i, _, _| *i);
         let exp = first_yes.unwrap();
         TestResult::from_bool(res == exp)
     }
@@ -97,7 +136,7 @@ mod tests {
     #[test]
     fn least_satisfying_1() {
         assert_eq!(
-            least_satisfying(&[No, Unknown, Unknown, No, Yes], |i| *i),
+            least_satisfying(&[No, Unknown, Unknown, No, Yes], |i, _, _| *i),
             4
         );
     }
@@ -105,43 +144,46 @@ mod tests {
     #[test]
     fn least_satisfying_2() {
         assert_eq!(
-            least_satisfying(&[No, Unknown, Yes, Unknown, Yes], |i| *i),
+            least_satisfying(&[No, Unknown, Yes, Unknown, Yes], |i, _, _| *i),
             2
         );
     }
 
     #[test]
     fn least_satisfying_3() {
-        assert_eq!(least_satisfying(&[No, No, No, No, Yes], |i| *i), 4);
+        assert_eq!(least_satisfying(&[No, No, No, No, Yes], |i, _, _| *i), 4);
     }
 
     #[test]
     fn least_satisfying_4() {
-        assert_eq!(least_satisfying(&[No, No, Yes, Yes, Yes], |i| *i), 2);
+        assert_eq!(least_satisfying(&[No, No, Yes, Yes, Yes], |i, _, _| *i), 2);
     }
 
     #[test]
     fn least_satisfying_5() {
-        assert_eq!(least_satisfying(&[No, Yes, Yes, Yes, Yes], |i| *i), 1);
+        assert_eq!(least_satisfying(&[No, Yes, Yes, Yes, Yes], |i, _, _| *i), 1);
     }
 
     #[test]
     fn least_satisfying_6() {
         assert_eq!(
-            least_satisfying(&[No, Yes, Yes, Unknown, Unknown, Yes, Unknown, Yes], |i| *i),
+            least_satisfying(
+                &[No, Yes, Yes, Unknown, Unknown, Yes, Unknown, Yes],
+                |i, _, _| *i
+            ),
             1
         );
     }
 
     #[test]
     fn least_satisfying_7() {
-        assert_eq!(least_satisfying(&[No, Yes, Unknown, Yes], |i| *i), 1);
+        assert_eq!(least_satisfying(&[No, Yes, Unknown, Yes], |i, _, _| *i), 1);
     }
 
     #[test]
     fn least_satisfying_8() {
         assert_eq!(
-            least_satisfying(&[No, Unknown, No, No, Unknown, Yes, Yes], |i| *i),
+            least_satisfying(&[No, Unknown, No, No, Unknown, Yes, Yes], |i, _, _| *i),
             5
         );
     }
@@ -149,6 +191,22 @@ mod tests {
     #[test]
     fn qc_prop() {
         QuickCheck::new().quickcheck(prop as fn(_) -> _);
+    }
+
+    #[test]
+    fn estimates() {
+        for (n, expect) in &[
+            (0, 0),
+            (1, 0),
+            (2, 0),
+            (3, 1),
+            (4, 1),
+            (5, 1),
+            (6, 2),
+            (150, 6),
+        ] {
+            assert_eq!(estimate_steps(*n), *expect);
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -637,6 +637,11 @@ impl Config {
         eprintln!("searched toolchains {} through {}", start, end);
 
         if toolchains[*found] == *toolchains.last().unwrap() {
+            // FIXME: Ideally the BisectionResult would contain the final result.
+            // This ends up testing a toolchain that was already tested.
+            // I believe this is one of the duplicates mentioned in
+            // https://github.com/rust-lang/cargo-bisect-rustc/issues/85
+            eprintln!("checking last toolchain to determine final result");
             let t = &toolchains[*found];
             let r = match t.install(&self.client, dl_spec) {
                 Ok(()) => {
@@ -839,7 +844,10 @@ impl Config {
     }
 
     fn bisect_to_regression(&self, toolchains: &[Toolchain], dl_spec: &DownloadParams) -> usize {
-        least_satisfying(toolchains, |t| {
+        least_satisfying(toolchains, |t, remaining, estimate| {
+            eprintln!(
+                "{remaining} versions remaining to test after this (roughly {estimate} steps)"
+            );
             self.install_and_test(t, dl_spec)
                 .unwrap_or(Satisfies::Unknown)
         })
@@ -925,6 +933,7 @@ impl Config {
                 );
             }
 
+            eprintln!("checking the start range to find a passing nightly");
             match self.install_and_test(&t, &dl_spec) {
                 Ok(r) => {
                     // If Satisfies::No, then the regression was not identified in this nightly.
@@ -971,6 +980,7 @@ impl Config {
         t_end.std_targets.sort();
         t_end.std_targets.dedup();
 
+        eprintln!("checking the end range to verify it does not pass");
         let result_nightly = self.install_and_test(&t_end, &dl_spec)?;
         // The regression was not identified in this nightly.
         if result_nightly == Satisfies::No {
@@ -1117,6 +1127,7 @@ impl Config {
 
         if !toolchains.is_empty() {
             // validate commit at start of range
+            eprintln!("checking the start range to verify it passes");
             let start_range_result = self.install_and_test(&toolchains[0], &dl_spec)?;
             if start_range_result == Satisfies::Yes {
                 bail!(
@@ -1126,6 +1137,7 @@ impl Config {
             }
 
             // validate commit at end of range
+            eprintln!("checking the end range to verify it does not pass");
             let end_range_result =
                 self.install_and_test(&toolchains[toolchains.len() - 1], &dl_spec)?;
             if end_range_result == Satisfies::No {


### PR DESCRIPTION
This adds some reporting to let the user know more about what cargo-bisect-rustc is doing, and provides an estimate of how many more steps it is going to do.

This is not perfect by any means, but seems to provide a decent enough approximation. Some limitations:

* It doesn't consider toolchains that fail to install (unknown_ranges). 
* It doesn't differentiate between nightlies and commits. So if you start with nightlies it will tell you N steps left, and then when it starts testing commits, the estimate starts over again.
* It doesn't include the initial start/end check in the estimate. It might be nice, but not trivial to handle.
* It doesn't consider the last check in `print_results`. Ideally that step should be removed (see #85).

Fixes #143
