### PR TITLE
Fix CI test error.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 on:
   pull_request:
   push:
+permissions:
+  contents: read
 jobs:
   test:
     name: Test
@@ -23,4 +25,6 @@ jobs:
     - name: Build
       run: cargo test --no-run
     - name: Test
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: cargo test


### PR DESCRIPTION
The `test_github` test has been sporadically failing on CI. The error is due to rate limiting:

Forbidden: {"message":"API rate limit exceeded for 52.255.184.219. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}

This fixes the issue by adding a GITHUB_TOKEN, which has a higher rate limit than the unauthenticated request.  There's still a rate limit, but I think it should be enough for normal CI runs.

This also adds more context to the error message when it happens.

Fixes #166