### PR TITLE
Count any thread stack overflow as an ICE

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -282,7 +282,7 @@ impl Config {
         );
 
         let saw_ice = stderr_utf8.contains("error: internal compiler error")
-            || stderr_utf8.contains("thread 'rustc' has overflowed its stack");
+            || stderr_utf8.contains("' has overflowed its stack");
 
         let input = (self.args.regress, status.success());
         let result = match input {


### PR DESCRIPTION
To catch e.g. `thread 'LTO module rust_out.a7c7f09e-cgu.0' has overflowed its stack`