### PR TITLE
Dependabot: Ignore patch level updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 20
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Keeping them constantly updated has limited benefits while it annoys the maintainers. In the ~2.5 months Dependabot has been enabled it filed 44 PRs. With this configuration, it would have only filed 4 PRs.