### PR TITLE
tests: Fix tests if the HOST triple is too long

### DIFF
--- a/tests/cmd/h.stdout
+++ b/tests/cmd/h.stdout
@@ -15,7 +15,7 @@ Options:
                                 (YYYY-MM-DD), git tag name (e.g. 1.58.0) or git commit SHA.
       --force-install           Force installation over existing artifacts
   -h, --help                    Print help information (use `--help` for more detail)
-      --host <HOST>             Host triple for the compiler [default: [..]]
+...
       --install <INSTALL>       Install the given artifact
       --preserve                Preserve the downloaded artifacts
       --preserve-target         Preserve the target directory used for builds


### PR DESCRIPTION
The HOST triple defaults to the current host and gets printed in the help output. The CLI tests currently match it with `[..]`. However, if the triple is too long clap might introduce a line break, which `[..]` can't handle.
Use `...` instead to match arbitrary lines at the position. Not elegant, but these are just smoke tests to ensure there's no major probelm. They are not meant to ensure 100% stable output.

Fixes: https://github.com/rust-lang/cargo-bisect-rustc/issues/226