### PR TITLE
Have rustfmt reorder imports

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,0 @@
-reorder_imports = false

--- a/src/git.rs
+++ b/src/git.rs
@@ -7,8 +7,8 @@ use std::env;
 use std::ops::Deref;
 use std::path::Path;
 
-use chrono::{TimeZone, Utc};
 use anyhow::{bail, Context};
+use chrono::{TimeZone, Utc};
 use git2::build::RepoBuilder;
 use git2::{Commit as Git2Commit, Repository};
 use log::debug;

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,9 +1,9 @@
 use anyhow::{bail, Context};
+use reqwest::header::{HeaderMap, HeaderValue, InvalidHeaderValue, AUTHORIZATION, USER_AGENT};
 use reqwest::{self, blocking::Client, blocking::Response};
-use reqwest::header::{HeaderMap, InvalidHeaderValue, HeaderValue, USER_AGENT, AUTHORIZATION};
 use serde::{Deserialize, Serialize};
 
-use crate::{Commit, GitDate, parse_to_utc_date};
+use crate::{parse_to_utc_date, Commit, GitDate};
 
 #[derive(Serialize, Deserialize, Debug)]
 struct GithubCommitComparison {

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,10 +13,10 @@ use std::path::PathBuf;
 use std::process;
 use std::str::FromStr;
 
+use anyhow::{bail, Context};
 use chrono::{Date, Duration, NaiveDate, Utc};
 use clap::{ArgAction, Parser, ValueEnum};
 use colored::Colorize;
-use anyhow::{bail, Context};
 use log::debug;
 use reqwest::blocking::Client;
 
@@ -29,8 +29,8 @@ mod toolchains;
 use crate::least_satisfying::{least_satisfying, Satisfies};
 use crate::repo_access::{AccessViaGithub, AccessViaLocalGit, RustRepositoryAccessor};
 use crate::toolchains::{
-    DownloadParams, InstallError, NIGHTLY_SERVER, TestOutcome, Toolchain, ToolchainSpec,
-    YYYY_MM_DD, download_progress, parse_to_utc_date,
+    download_progress, parse_to_utc_date, DownloadParams, InstallError, TestOutcome, Toolchain,
+    ToolchainSpec, NIGHTLY_SERVER, YYYY_MM_DD,
 };
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/repo_access.rs
+++ b/src/repo_access.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 
-use crate::{Bound, Commit, GitDate, git, github};
+use crate::{git, github, Bound, Commit, GitDate};
 
 pub(crate) trait RustRepositoryAccessor {
     /// Maps `bound` to its associated date, looking up its commit if necessary.


### PR DESCRIPTION
It was disabled several years back to "avoid formatting thrash". Back then CI didn't enforce a consistent formatting yet and presumably different rustfmt versions disagreed about the correct ordering of imports.