### PR TITLE
Loosen `rust-lang/rust` remote check

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -108,7 +108,11 @@ fn find_origin_remote(repo: &Repository) -> anyhow::Result<String> {
     repo.remotes()?
         .iter()
         .filter_map(|name| name.and_then(|name| repo.find_remote(name).ok()))
-        .find(|remote| remote.url().map_or(false, |url| url.contains("rust-lang/rust")))
+        .find(|remote| {
+            remote
+                .url()
+                .map_or(false, |url| url.contains("rust-lang/rust"))
+        })
         .and_then(|remote| remote.name().map(std::string::ToString::to_string))
         .with_context(|| {
             format!(

--- a/src/git.rs
+++ b/src/git.rs
@@ -108,7 +108,7 @@ fn find_origin_remote(repo: &Repository) -> anyhow::Result<String> {
     repo.remotes()?
         .iter()
         .filter_map(|name| name.and_then(|name| repo.find_remote(name).ok()))
-        .find(|remote| remote.url().map_or(false, |url| url.contains(RUST_SRC_URL)))
+        .find(|remote| remote.url().map_or(false, |url| url.contains("rust-lang/rust")))
         .and_then(|remote| remote.name().map(std::string::ToString::to_string))
         .with_context(|| {
             format!(


### PR DESCRIPTION
This permits remote URLs such as `git@github.com:rust-lang/rust.git`