### PR TITLE
Try running script from working directory

### DIFF
--- a/src/toolchains.rs
+++ b/src/toolchains.rs
@@ -238,17 +238,11 @@ impl Toolchain {
                     .join(&format!("target-{}", self.rustup_name())),
             );
         }
-        let mut script = cfg.args.script.clone();
-        if let Some(path) = &script {
-            if !path.is_absolute() && !path.starts_with("./") && !path.starts_with(".\\") {
-                if let Ok(mut dir) = std::env::current_dir() {
-                    dir.push(path);
-                    if dir.is_file() {
-                        script = Some(dir)
-                    }
-                }
-            }
-        }
+        let script = cfg
+            .args
+            .script
+            .as_ref()
+            .map(|script| std::env::current_dir().unwrap().join(script));
 
         let mut cmd = match (script, cfg.args.timeout) {
             (Some(script), None) => {

--- a/src/toolchains.rs
+++ b/src/toolchains.rs
@@ -238,8 +238,19 @@ impl Toolchain {
                     .join(&format!("target-{}", self.rustup_name())),
             );
         }
+        let mut script = cfg.args.script.clone();
+        if let Some(path) = &script {
+            if !path.is_absolute() && !path.starts_with("./") && !path.starts_with(".\\") {
+                if let Ok(mut dir) = std::env::current_dir() {
+                    dir.push(path);
+                    if dir.exists() {
+                        script = Some(dir)
+                    }
+                }
+            }
+        }
 
-        let mut cmd = match (cfg.args.script.as_ref(), cfg.args.timeout) {
+        let mut cmd = match (script, cfg.args.timeout) {
             (Some(script), None) => {
                 let mut cmd = Command::new(script);
                 cmd.env("RUSTUP_TOOLCHAIN", self.rustup_name());

--- a/src/toolchains.rs
+++ b/src/toolchains.rs
@@ -243,7 +243,7 @@ impl Toolchain {
             if !path.is_absolute() && !path.starts_with("./") && !path.starts_with(".\\") {
                 if let Ok(mut dir) = std::env::current_dir() {
                     dir.push(path);
-                    if dir.exists() {
+                    if dir.is_file() {
                         script = Some(dir)
                     }
                 }


### PR DESCRIPTION
Fixes #234 
If we have a non-absolute path that doesn't begin with `./`, check for the script in the current directory and adjust the script path if it exists.