### PR TITLE
Use debug printing for anyhow errors to show the full cause and context

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1165,7 +1165,7 @@ fn main() {
             Ok(ExitError(code)) => process::exit(code),
             Err(err) => {
                 let error_str = "ERROR:".red().bold();
-                eprintln!("{} {}", error_str, err);
+                eprintln!("{} {:?}", error_str, err);
                 process::exit(1);
             }
         }


### PR DESCRIPTION
The top-level anyhow context is often not enough for the user to fully diagnose the issue that's occurring, such as in issue #233. This changes from `Display` to `Debug` printing to show the full context and backtrace if available. 