### PR TITLE
--start without --end defaults `end` to be today

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -859,10 +859,14 @@ fn get_start_date(cfg: &Config) -> Date<Utc> {
 fn get_end_date(cfg: &Config) -> Date<Utc> {
     if let Some(Bound::Date(date)) = cfg.args.end {
         date
-    } else if let Some(date) = Toolchain::default_nightly() {
-        date
     } else {
-        Utc::today()
+        match (Toolchain::default_nightly(), &cfg.args.start) {
+            // Neither --start or --end specified, default to the current
+            // nightly (if available).
+            (Some(date), None) => date,
+            // --start only, assume --end=today
+            _ => Utc::today(),
+        }
     }
 }
 


### PR DESCRIPTION
Previously, specifying `--start` without `--end` would cause `--end` to default to the current nightly compiler. However, if the current nightly is old, that could be even older than `--start`. This changes the logic so that in that scenario it will always use "today" as the default date for `--end`.

This used to use similar logic, but it was removed in 44af4fdd7e154026e1610fee9910c27ded0a9fc0. Based on the commit comment, I'm presuming this was not intentional.
