### PR TITLE
Fix bounds checking with missing bound.

### DIFF
--- a/tests/cmd/start-in-future.stderr
+++ b/tests/cmd/start-in-future.stderr
@@ -1,1 +1,1 @@
-ERROR: start date must be on or before the current date. received start date request 9999-01-01UTC
+ERROR: start date should be on or before current date, got start date request: 9999-01-01UTC and current date is [..]UTC


### PR DESCRIPTION
Before this, checking that start and end are both before the current date when either one of start or end is missing didn't work.

This was detected by the command-line tests that are run when building this in [nixpkgs](https://github.com/NixOS/nixpkgs).