### PR TITLE
Switch the action for installing rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,9 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust }}
-        profile: minimal
-        override: true
     - uses: Swatinem/rust-cache@v2
     - name: Build
       run: cargo test --no-run


### PR DESCRIPTION
The actions-rs/toolchain action is no longer maintained and is generating several deprecation warnings. This switches to dtolnay/rust-toolchain, which should be more reliable.