### PR TITLE
Don't run CI on dependabot branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 on:
   pull_request:
   push:
+    branches-ignore:
+      - 'dependabot/**'
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
Currenly CI is run twice for each update initiated by dependabot. Once on the PR and once on the branch.