### PR TITLE
Detect more kinds of ICE

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -265,7 +265,8 @@ impl Config {
         );
 
         let saw_ice = stderr_utf8.contains("error: internal compiler error")
-            || stderr_utf8.contains("' has overflowed its stack");
+            || stderr_utf8.contains("' has overflowed its stack")
+            || stderr_utf8.contains("error: the compiler unexpectedly panicked");
 
         let input = (self.args.regress, status.success());
         let result = match input {


### PR DESCRIPTION
Currently, panics due to things like `.unwrap()` aren't detected. Found as part of https://github.com/rust-lang/rust/issues/108529 