### PR TITLE
Fetch tags when updating the rust repo

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -72,7 +72,7 @@ fn get_repo() -> anyhow::Result<RustcRepo> {
         eprintln!("refreshing repository at {:?}", path);
         // This uses the CLI because libgit2 is quite slow to fetch a large repository.
         let status = std::process::Command::new("git")
-            .arg("fetch")
+            .args(&["fetch", "--tags"])
             .arg(&origin_remote)
             .current_dir(path)
             .status()


### PR DESCRIPTION
When bisecting on a tag (like `1.67.0`), and the repo doesn't have that tag, then it would fail. This updates the call to `git fetch` to ensure the tags are fetched.
