### PR TITLE
Fix script example for diagnostic grepping

### DIFF
--- a/guide/src/examples/diagnostics.md
+++ b/guide/src/examples/diagnostics.md
@@ -24,7 +24,7 @@ echo "$OUTPUT"
 # This indicates a regression when the text "non-ASCII" is in the output.
 #
 # If the regression is when the text is *not* in the output, remove the `!` prefix.
-! grep "non-ASCII" "$OUTPUT"
+! echo "$OUTPUT" | grep "non-ASCII"
 ```
 
 Then run something like:


### PR DESCRIPTION
This fixes a mistake in the example for grepping for diagnostic output.