### PR TITLE
Fix bisecting into rollups via unrolled perf builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr",
 ]
@@ -89,6 +89,7 @@ dependencies = [
  "log",
  "pbr",
  "quickcheck",
+ "regex",
  "reqwest",
  "rustc_version",
  "serde",
@@ -1203,9 +1204,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.6"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1214,9 +1215,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.26"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "reqwest"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1114,9 +1114,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.46"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ tempfile = "3"
 xz2 = "0.1.7"
 chrono = "0.4.22"
 colored = "2"
+regex = "1.8.4"
 
 [dev-dependencies]
 quickcheck = "1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1354,4 +1354,74 @@ mod tests {
             validate_dir(main).unwrap_err()
         )
     }
+
+    // Ensure the first version of the comment posted by the perf-bot works
+    #[test]
+    fn test_perf_builds_v1_format() {
+        // Body extracted from this v1 comment
+        // https://github.com/rust-lang/rust/pull/113014#issuecomment-1605868471
+        let body = "📌 Perf builds for each rolled up PR:
+
+|PR# | Perf Build Sha|
+|----|:-----:|
+|#113009|[05b07dad146a6d43ead9bcd1e8bc10cbd017a5f5](https://github.com/rust-lang-ci/rust/commit/05b07dad146a6d43ead9bcd1e8bc10cbd017a5f5)|
+|#113008|[581913b6789370def5158093b799baa6d4d875eb](https://github.com/rust-lang-ci/rust/commit/581913b6789370def5158093b799baa6d4d875eb)|
+|#112956|[e294bd3827eb2e878167329648f3c8178ef344e7](https://github.com/rust-lang-ci/rust/commit/e294bd3827eb2e878167329648f3c8178ef344e7)|
+|#112950|[0ed6ba504649ca1cb2672572b4ab41acfb06c86c](https://github.com/rust-lang-ci/rust/commit/0ed6ba504649ca1cb2672572b4ab41acfb06c86c)|
+|#112937|[18e108ab85b78e6966c5b5bdadfd5b8efeadf080](https://github.com/rust-lang-ci/rust/commit/18e108ab85b78e6966c5b5bdadfd5b8efeadf080)|
+
+
+*previous master*: [f7ca9df695](https://github.com/rust-lang-ci/rust/commit/f7ca9df69549470541fbf542f87a03eb9ed024b6)
+
+In the case of a perf regression, run the following command for each PR you suspect might be the cause: `@rust-timer build $SHA`
+<!-- rust-timer: rollup -->";
+        assert_eq!(
+            vec![
+                "05b07dad146a6d43ead9bcd1e8bc10cbd017a5f5",
+                "581913b6789370def5158093b799baa6d4d875eb",
+                "e294bd3827eb2e878167329648f3c8178ef344e7",
+                "0ed6ba504649ca1cb2672572b4ab41acfb06c86c",
+                "18e108ab85b78e6966c5b5bdadfd5b8efeadf080",
+            ],
+            extract_perf_shas(body).expect("extracting perf builds on v1 format failed"),
+        );
+    }
+
+    // Ensure the second version of the comment posted by the perf-bot works
+    #[test]
+    fn test_perf_builds_v2_format() {
+        // Body extracted from this v2 comment
+        // https://github.com/rust-lang/rust/pull/113105#issuecomment-1610393473
+        let body = "📌 Perf builds for each rolled up PR:
+
+| PR# | Message | Perf Build Sha |
+|----|----|:-----:|
+|#112207|Add trustzone and virtualization target features for aarch3…|`bbec6d6e413aa144c8b9346da27a0f2af299cbeb` ([link](https://github.com/rust-lang-ci/rust/commit/bbec6d6e413aa144c8b9346da27a0f2af299cbeb))|
+|#112454|Make compiletest aware of targets without dynamic linking|`70b67c09ead52f4582471650202b1a189821ed5f` ([link](https://github.com/rust-lang-ci/rust/commit/70b67c09ead52f4582471650202b1a189821ed5f))|
+|#112628|Allow comparing `Box`es with different allocators|`3043f4e577f41565443f38a6a16b7a1a08b063ad` ([link](https://github.com/rust-lang-ci/rust/commit/3043f4e577f41565443f38a6a16b7a1a08b063ad))|
+|#112692|Provide more context for `rustc +nightly -Zunstable-options…|`4ab6f33fd50237b105999cc6d32d85cce5dad61a` ([link](https://github.com/rust-lang-ci/rust/commit/4ab6f33fd50237b105999cc6d32d85cce5dad61a))|
+|#112972|Make `UnwindAction::Continue` explicit in MIR dump|`e1df9e306054655d7d41ec1ad75ade5d76a6888d` ([link](https://github.com/rust-lang-ci/rust/commit/e1df9e306054655d7d41ec1ad75ade5d76a6888d))|
+|#113020|Add tests impl via obj unless denied|`affe009b94eba41777cf02997b1780e50445d6af` ([link](https://github.com/rust-lang-ci/rust/commit/affe009b94eba41777cf02997b1780e50445d6af))|
+|#113084|Simplify some conditions|`0ce4618dbf5810aabb389edd4950c060b6b4d049` ([link](https://github.com/rust-lang-ci/rust/commit/0ce4618dbf5810aabb389edd4950c060b6b4d049))|
+|#113103|Normalize types when applying uninhabited predicate.|`241cd8cd818cdc865cdf02f0c32a40081420b772` ([link](https://github.com/rust-lang-ci/rust/commit/241cd8cd818cdc865cdf02f0c32a40081420b772))|
+
+
+*previous master*: [5ea6668646](https://github.com/rust-lang-ci/rust/commit/5ea66686467d3ec5f8c81570e7f0f16ad8dd8cc3)
+
+In the case of a perf regression, run the following command for each PR you suspect might be the cause: `@rust-timer build $SHA`
+<!-- rust-timer: rollup -->";
+        assert_eq!(
+            vec![
+                "bbec6d6e413aa144c8b9346da27a0f2af299cbeb",
+                "70b67c09ead52f4582471650202b1a189821ed5f",
+                "3043f4e577f41565443f38a6a16b7a1a08b063ad",
+                "4ab6f33fd50237b105999cc6d32d85cce5dad61a",
+                "e1df9e306054655d7d41ec1ad75ade5d76a6888d",
+                "affe009b94eba41777cf02997b1780e50445d6af",
+                "0ce4618dbf5810aabb389edd4950c060b6b4d049",
+                "241cd8cd818cdc865cdf02f0c32a40081420b772",
+            ],
+            extract_perf_shas(body).expect("extracting perf builds on v2 format failed"),
+        );
+    }
 }


### PR DESCRIPTION
The perfbot comment on rollups has [recently changed format](https://github.com/rust-lang/rustc-perf/pull/1623), breaking the commit extraction from that comment.

Also updates proc-macro2 to fix build errors on nightly.

Now uses a regex to look for the shas found in the perf table column, to support both formats:
- https://github.com/rust-lang/rust/pull/113014#issuecomment-1605868471
- https://github.com/rust-lang/rust/pull/113105#issuecomment-1610393473