### PR TITLE
switch CI downloads to use CI artifacts URL

### DIFF
--- a/src/toolchains.rs
+++ b/src/toolchains.rs
@@ -22,7 +22,7 @@ use crate::{Config, GitDate};
 pub const YYYY_MM_DD: &str = "%Y-%m-%d";
 
 pub(crate) const NIGHTLY_SERVER: &str = "https://static.rust-lang.org/dist";
-const CI_SERVER: &str = "https://s3-us-west-1.amazonaws.com/rust-lang-ci2";
+const CI_SERVER: &str = "https://ci-artifacts.rust-lang.org";
 
 #[derive(thiserror::Error, Debug)]
 pub(crate) enum InstallError {


### PR DESCRIPTION
If I understand correctly, https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/rustc.20nightly.20download.20speed/near/378145048 means that `cargo-bisect-rustc` should be using the CI artifacts URL to allow for better caching and CDNs.

draft until confirmation from @pietroalbini that this is needed, and @bjorn3 to see if this fixes their S3 download speed