### PR TITLE
Default to `--access github`

### DIFF
--- a/guide/src/rust-src-repo.md
+++ b/guide/src/rust-src-repo.md
@@ -3,10 +3,30 @@
 For `cargo-bisect-rustc` to work, it needs to be able to read the git log of the [`rust-lang/rust`] repo.
 `cargo-bisect-rustc` supports several methods for this described below.
 
+## GitHub API
+
+By default, `cargo-bisect-rustc` uses the GitHub API to fetch the information instead of using a local checkout.
+
+```sh
+cargo bisect-rustc --access=github
+```
+
+Beware that GitHub has restrictive rate limits for unauthenticated requests.
+It allows 60 requests per hour, and `cargo-bisect-rustc` will use about 10 requests each time you run it (which can vary depending on the bisection).
+If you run into the rate limit, you can raise it to 5000 requests per hour by setting the `GITHUB_TOKEN` environment variable to a [GitHub personal token].
+If you use the [`gh` CLI tool], you can use it to get a token:
+
+```sh
+GITHUB_TOKEN=`gh auth token` cargo bisect-rustc --access=github
+```
+
+If you don't use `gh`, you'll just need to copy and paste the token.
+
 ## Local clone
 
-By default, `cargo-bisect-rustc` will clone the rust repo in the current directory (as `rust.git`).
-This option can be quite slow, but doesn't require any setup.
+`cargo-bisect-rustc` can also clone the rust repo in the current directory (as `rust.git`).
+This option can be quite slow if you don't specify the repo path at build time.
+You can specify this with the `--access` CLI argument:
 
 ## `RUST_SRC_REPO` environment variable
 
@@ -25,26 +45,6 @@ This is recommended if you already have the rust repo checked out somewhere.
 ```sh
 RUST_SRC_REPO=/path/to/rust cargo install cargo-bisect-rustc
 ```
-
-## GitHub API
-
-`cargo-bisect-rustc` can use the GitHub API to fetch the information instead of using a local checkout.
-You can specify this with the `--access` CLI argument:
-
-```sh
-cargo bisect-rustc --access=github
-```
-
-Beware that GitHub has restrictive rate limits for unauthenticated requests.
-It allows 60 requests per hour, and `cargo-bisect-rustc` will use about 10 requests each time you run it (which can vary depending on the bisection).
-If you run into the rate limit, you can raise it to 5000 requests per hour by setting the `GITHUB_TOKEN` environment variable to a [GitHub personal token].
-If you use the [`gh` CLI tool], you can use it to get a token:
-
-```sh
-GITHUB_TOKEN=`gh auth token` cargo bisect-rustc --access=github
-```
-
-If you don't use `gh`, you'll just need to copy and paste the token.
 
 [`rust-lang/rust`]: https://github.com/rust-lang/rust/
 [GitHub personal token]: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,7 +166,7 @@ a date (YYYY-MM-DD), git tag name (e.g. 1.58.0) or git commit SHA."
     #[arg(long, help = "Bisect via commit artifacts")]
     by_commit: bool,
 
-    #[arg(long, value_enum, help = "How to access Rust git repository", default_value_t = Access::Checkout)]
+    #[arg(long, value_enum, help = "How to access Rust git repository", default_value_t = Access::Github)]
     access: Access,
 
     #[arg(long, help = "Install the given artifact")]

--- a/tests/cmd/h.stdout
+++ b/tests/cmd/h.stdout
@@ -7,7 +7,7 @@ Arguments:
 
 Options:
   -a, --alt                     Download the alt build instead of normal build
-      --access <ACCESS>         How to access Rust git repository [default: checkout] [possible
+      --access <ACCESS>         How to access Rust git repository [default: github] [possible
                                 values: checkout, github]
       --by-commit               Bisect via commit artifacts
   -c, --component <COMPONENTS>  additional components to install

--- a/tests/cmd/help.stdout
+++ b/tests/cmd/help.stdout
@@ -13,7 +13,7 @@ Options:
       --access <ACCESS>
           How to access Rust git repository
           
-          [default: checkout]
+          [default: github]
           [possible values: checkout, github]
 
       --by-commit


### PR DESCRIPTION
I've been using `cargo-bisect-rustc` for a while now, and `--access
github` has never caused any problems. Maybe it can run into
ratelimiting in extreme cases, but the user should then just use `git`.

Meanwhile, git is a very confusing default as it will suddelny just
start cloning the repo unless you were very careful when installing.