### PR TITLE
Clarify docs about local src usage

### DIFF
--- a/guide/src/examples/diagnostics.md
+++ b/guide/src/examples/diagnostics.md
@@ -6,7 +6,7 @@ For example, this can check when either the wording has changed, or a different 
 [#109067](https://github.com/rust-lang/rust/issues/109067) is an example of where this is necessary.
 A warning started being emitted, and it is the kind of warning that cannot be turned into an error with `deny(warnings)`.
 
-The following script is intended to be used with the `--script` option:
+The following script is intended to be used with the `--script` option (set the executable flag on the script, `chmod u+x`):
 
 ```sh
 #!/bin/sh

--- a/guide/src/rust-src-repo.md
+++ b/guide/src/rust-src-repo.md
@@ -27,6 +27,9 @@ If you don't use `gh`, you'll just need to copy and paste the token.
 `cargo-bisect-rustc` can also clone the rust repo in the current directory (as `rust.git`).
 This option can be quite slow if you don't specify the repo path at build time.
 You can specify this with the `--access` CLI argument:
+```sh
+cargo bisect-rustc --access=checkout
+```
 
 ## `RUST_SRC_REPO` environment variable
 


### PR DESCRIPTION
After looking at the new default source access in #307 I've found that docs are missing a suggestion on how to use `--access=checkout`.

While I was there I clarified that the user-provided script to test rustc bisection must be executable (i always used to trip on that)