### PR TITLE
Improve debug wording

### DIFF
--- a/src/least_satisfying.rs
+++ b/src/least_satisfying.rs
@@ -174,7 +174,11 @@ pub enum Satisfies {
 
 impl fmt::Display for Satisfies {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        match self {
+            Self::Yes => write!(f, "Reproduces the regression"),
+            Self::No => write!(f, "Does not reproduce the regression"),
+            Self::Unknown => writeln!(f, "Unable to figure out if it reproduces the regression"),
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1159,7 +1159,9 @@ impl Config {
 
         if !toolchains.is_empty() {
             // validate commit at start of range
-            eprintln!("checking the start range to verify it passes");
+            eprintln!(
+                "checking the start range: testing the sample code, should not reproduce the regression"
+            );
             let start_range_result = self.install_and_test(&toolchains[0], &dl_spec)?;
             if start_range_result == Satisfies::Yes {
                 bail!(
@@ -1169,7 +1171,9 @@ impl Config {
             }
 
             // validate commit at end of range
-            eprintln!("checking the end range to verify it does not pass");
+            eprintln!(
+                "checking the end range: testing the sample code, should reproduce the regression"
+            );
             let end_range_result =
                 self.install_and_test(&toolchains[toolchains.len() - 1], &dl_spec)?;
             if end_range_result == Satisfies::No {


### PR DESCRIPTION
A user recently mentioned that the wording of cargo bisect during the bisection is a bit unclear (https://togithub.com/rust-lang/rust/issues/119822#issuecomment-1929153702), namely what do the messages after every test mean.

With this patch I'm trying to make it clearer (I hope I got the logic right).

thanks for checking this out!

r? @ehuss 