### PR TITLE
fix getting working commit with missing nightlies

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Context};
 use reqwest::header::{HeaderMap, HeaderValue, InvalidHeaderValue, AUTHORIZATION, USER_AGENT};
-use reqwest::{self, blocking::Client, blocking::Response};
+use reqwest::{blocking::Client, blocking::Response};
 use serde::{Deserialize, Serialize};
 
 use crate::{parse_to_naive_date, Commit, GitDate};


### PR DESCRIPTION
The previous implementation assumed that the most recent working nightly is from one day before the regressed nightly. But that's sometimes not the case if there are missing nightly versions. This PR fixes getting the working nightly version by trying the previous dates until we find one that actually has a nightly.

### Test Case

code:

```rust
trait Foo {
    fn foo() {
        pub struct Bar;
        impl Bar {
            pub fn bar() {}
        }
    }
}
```

run:

```
cargo bisect-rustc --start 2024-01-01 --end 2024-01-04
```

output before:

```
fetching https://static.rust-lang.org/dist/2024-01-03/channel-rust-nightly-git-commit-hash.txt
ERROR: Tarball not found at https://static.rust-lang.org/dist/2024-01-03/channel-rust-nightly-git-commit-hash.txt
```

output after:

```
fetching https://static.rust-lang.org/dist/2024-01-03/channel-rust-nightly-git-commit-hash.txt
missing nightly for 2024-01-03
fetching https://static.rust-lang.org/dist/2024-01-02/channel-rust-nightly-git-commit-hash.txt
missing nightly for 2024-01-02
fetching https://static.rust-lang.org/dist/2024-01-01/channel-rust-nightly-git-commit-hash.txt
nightly manifest 2024-01-01: 40 B / 40 B [==============] 100.00 % 1.02 MB/s
converted 2024-01-01 to e51e98dde6a60637b6a71b8105245b629ac3fe77
```

---

fixes https://github.com/rust-lang/cargo-bisect-rustc/issues/51