### PR TITLE
Do not unconditionally set the target.

### DIFF
--- a/guide/src/examples/rustdoc.md
+++ b/guide/src/examples/rustdoc.md
@@ -21,7 +21,7 @@ set -e
 
 cargo doc
 
-grep "some example text" $CARGO_TARGET_DIR/$CARGO_BUILD_TARGET/doc/mycrate/fn.foo.html
+grep "some example text" $CARGO_TARGET_DIR/doc/mycrate/fn.foo.html
 ```
 
 This can be used with the `--script` option:

--- a/guide/src/usage.md
+++ b/guide/src/usage.md
@@ -106,6 +106,6 @@ COUNT=`echo "$OUTPUT" | grep -c "unnecessary parentheses"`
 test $COUNT -eq 1
 ```
 
-If you need to use the targets directly without using `cargo` in the script, they are available in `$CARGO_TARGET_DIR/$CARGO_BUILD_TARGET/[release|debug]/...`, since `cargo-bisect-rustc` sets `$CARGO_TARGET_DIR` and `$CARGO_BUILD_TARGET`.
+If you need to use the targets directly without using `cargo` in the script, they are available in `$CARGO_TARGET_DIR/[release|debug]/...`, since `cargo-bisect-rustc` sets `$CARGO_TARGET_DIR`.
 
 Check out the [examples chapters](examples/index.md) for several examples of how to use this option.

--- a/src/toolchains.rs
+++ b/src/toolchains.rs
@@ -288,7 +288,9 @@ impl Toolchain {
         };
         cmd.current_dir(&cfg.args.test_dir);
         cmd.env("CARGO_TARGET_DIR", format!("target-{}", self.rustup_name()));
-        cmd.env("CARGO_BUILD_TARGET", &cfg.target);
+        if let Some(target) = &cfg.args.target {
+            cmd.env("CARGO_BUILD_TARGET", target);
+        }
 
         // let `cmd` capture stderr for us to process afterward.
         let must_capture_output = cfg.args.regress.must_process_stderr();


### PR DESCRIPTION
This removes the `CARGO_BUILD_TARGET` environment variable which causes cargo to unconditionally work in "cross compile mode". This is different from a normal `cargo` invocation without the `--target` flag, in which case it runs in "host mode", where cargo and other tools have distinctly different behavior. This can be surprising when you get one behavior with `cargo build` and a different one with `cargo bisect-rustc`.

This was added in #159 to address some issue with using `cross-rs` with `cargo bisect-rustc`. I'm not sure why, as I would think the recommended behavior when using cross is to set the `--target` flag. The given PR didn't really explain the situation.

Closes #284