### PR TITLE
Fix build script to prevent change scanning.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,4 +2,6 @@ use std::env;
 
 fn main() {
     println!("cargo:rustc-env=HOST={}", env::var("TARGET").unwrap());
+    // Prevents cargo from scanning the whole directory for changes.
+    println!("cargo:rerun-if-changed=build.rs");
 }


### PR DESCRIPTION
This fixes it so that the build script doesn't run every time a file changes. [Reference](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed)