### PR TITLE
Stop stripping and LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,6 @@ repository = "https://github.com/rust-lang/cargo-bisect-rustc"
 version = "0.6.8"
 edition = "2021"
 
-[profile.release]
-strip = "symbols"
-lto = "fat"
-
 [dependencies]
 dialoguer = { version = "0.11.0", default-features = false }
 home = "0.5"


### PR DESCRIPTION
**Stop stripping**:
Stripping symbols here is bad, because it makes the binary completely opaque and undebbuggable, should something ever go wrong. The binary size benefit is very minor, this program is supposed to run on desktop computers with tons of disk space. The tradeoff is bad.

I like to follow the rule of "do not ever strip symbols unless you absolutely need to", at least for programs on dev systems.

**Stop LTO**:
The same binary size non-concerns as stripping apply. Also, speed basically doesn't matter here. Meanwhile, we want this program to be `cargo install`-able, so compile times matter. Again, the tradeoff is bad.