### PR TITLE
Add a flag for pretending to be a stable compiler when bisecting.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -155,6 +155,13 @@ struct Opts {
 
     #[arg(
         long,
+        help = "Pretend to be a stable compiler (disable features, \
+report a version that looks like a stable version)"
+    )]
+    pretend_to_be_stable: bool,
+
+    #[arg(
+        long,
         help = "Left bound for search (*without* regression). You can use \
 a date (YYYY-MM-DD), git tag name (e.g. 1.58.0) or git commit SHA."
     )]

--- a/src/toolchains.rs
+++ b/src/toolchains.rs
@@ -257,12 +257,7 @@ impl Toolchain {
             }
             (None, None) => {
                 let mut cmd = Command::new("cargo");
-                cmd.arg(&format!("+{}", self.rustup_name()));
-                if cfg.args.command_args.is_empty() {
-                    cmd.arg("build");
-                } else {
-                    cmd.args(&cfg.args.command_args);
-                }
+                self.set_cargo_args_and_envs(&mut cmd, cfg);
                 cmd
             }
             (Some(script), Some(timeout)) => {
@@ -277,12 +272,7 @@ impl Toolchain {
                 let mut cmd = Command::new("timeout");
                 cmd.arg(timeout.to_string());
                 cmd.arg("cargo");
-                cmd.arg(format!("+{}", self.rustup_name()));
-                if cfg.args.command_args.is_empty() {
-                    cmd.arg("build");
-                } else {
-                    cmd.args(&cfg.args.command_args);
-                }
+                self.set_cargo_args_and_envs(&mut cmd, cfg);
                 cmd
             }
         };
@@ -324,6 +314,15 @@ impl Toolchain {
             io::stderr().write_all(&output.stderr).unwrap();
         }
         output
+    }
+
+    fn set_cargo_args_and_envs(&self, cmd: &mut Command, cfg: &Config) {
+        cmd.arg(&format!("+{}", self.rustup_name()));
+        if cfg.args.command_args.is_empty() {
+            cmd.arg("build");
+        } else {
+            cmd.args(&cfg.args.command_args);
+        }
     }
 
     pub(crate) fn test(&self, cfg: &Config) -> TestOutcome {

--- a/src/toolchains.rs
+++ b/src/toolchains.rs
@@ -317,11 +317,28 @@ impl Toolchain {
     }
 
     fn set_cargo_args_and_envs(&self, cmd: &mut Command, cfg: &Config) {
-        cmd.arg(&format!("+{}", self.rustup_name()));
+        let rustup_name = format!("+{}", self.rustup_name());
+        cmd.arg(&rustup_name);
         if cfg.args.command_args.is_empty() {
             cmd.arg("build");
         } else {
             cmd.args(&cfg.args.command_args);
+        }
+        if cfg.args.pretend_to_be_stable && self.is_current_nightly() {
+            // Forbid using features
+            cmd.env(
+                "RUSTFLAGS",
+                format!(
+                    "{} -Zallow-features=",
+                    std::env::var("RUSTFLAGS").unwrap_or_default()
+                ),
+            );
+            // Make rustc report a stable version string derived from the current nightly's version string.
+            let version = rustc_version::version_meta().unwrap().semver;
+            cmd.env(
+                "RUSTC_OVERRIDE_VERSION_STRING",
+                format!("{}.{}.{}", version.major, version.minor, version.patch),
+            );
         }
     }
 

--- a/tests/cmd/bare-h.stdout
+++ b/tests/cmd/bare-h.stdout
@@ -19,6 +19,8 @@ Options:
       --install <INSTALL>       Install the given artifact
       --preserve                Preserve the downloaded artifacts
       --preserve-target         Preserve the target directory used for builds
+      --pretend-to-be-stable    Pretend to be a stable compiler (disable features, report a version
+                                that looks like a stable version)
       --prompt                  Manually evaluate for regression with prompts
       --regress <REGRESS>       Custom regression definition [default: error] [possible values:
                                 error, success, ice, non-ice, non-error]

--- a/tests/cmd/bare-help.stdout
+++ b/tests/cmd/bare-help.stdout
@@ -46,6 +46,10 @@ Options:
       --preserve-target
           Preserve the target directory used for builds
 
+      --pretend-to-be-stable
+          Pretend to be a stable compiler (disable features, report a version that looks like a
+          stable version)
+
       --prompt
           Manually evaluate for regression with prompts
 

--- a/tests/cmd/h.stdout
+++ b/tests/cmd/h.stdout
@@ -19,6 +19,8 @@ Options:
       --install <INSTALL>       Install the given artifact
       --preserve                Preserve the downloaded artifacts
       --preserve-target         Preserve the target directory used for builds
+      --pretend-to-be-stable    Pretend to be a stable compiler (disable features, report a version
+                                that looks like a stable version)
       --prompt                  Manually evaluate for regression with prompts
       --regress <REGRESS>       Custom regression definition [default: error] [possible values:
                                 error, success, ice, non-ice, non-error]

--- a/tests/cmd/help.stdout
+++ b/tests/cmd/help.stdout
@@ -46,6 +46,10 @@ Options:
       --preserve-target
           Preserve the target directory used for builds
 
+      --pretend-to-be-stable
+          Pretend to be a stable compiler (disable features, report a version that looks like a
+          stable version)
+
       --prompt
           Manually evaluate for regression with prompts
 


### PR DESCRIPTION
This should avoid having to patch ahash and similar crates to not do nightly feature detection and break the bisection (see https://github.com/rust-lang/rust/issues/123276#issuecomment-2075001510 for an example).

We could also do this by default and add an opt-out flag for when you want to bisect code that uses feature gates