### PR TITLE
Update doc-change example.

### DIFF
--- a/guide/src/examples/doc-change.md
+++ b/guide/src/examples/doc-change.md
@@ -27,7 +27,8 @@ fi
 And run with:
 
 ```sh
-cargo bisect-rustc --start --end -c rust-docs --script ./test.sh
+cargo bisect-rustc --start 1.68.0 --end 1.69.0 -c rust-docs --script ./test.sh
 ```
 
 > **Note**: This may not work on all targets since `cargo-bisect-rustc` doesn't properly handle rustup manifests, which alias some targets to other targets.
+> Use `--host x86_64-unknown-linux-gnu` in that situation.


### PR DESCRIPTION
The example had an invalid command, where `--start` and `--end require an argument.

Additionally, explain how to work around the alias problem with `--host`.