### PR TITLE
Improve terms defaults

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -183,14 +183,12 @@ a date (YYYY-MM-DD), git tag name (e.g. 1.58.0) or git commit SHA."
 
     #[arg(
         long,
-        default_value = "Test condition NOT matched",
         help = "Text shown when a test fails to match the condition requested"
     )]
     term_new: Option<String>,
 
     #[arg(
         long,
-        default_value = "Test condition matched",
         help = "Text shown when a test does match the condition requested"
     )]
     term_old: Option<String>,

--- a/tests/cmd/h.stdout
+++ b/tests/cmd/h.stdout
@@ -29,9 +29,7 @@ Options:
                                 hangs)
       --target <TARGET>         Cross-compilation target platform
       --term-new <TERM_NEW>     Text shown when a test fails to match the condition requested
-                                [default: "Test condition NOT matched"]
-      --term-old <TERM_OLD>     Text shown when a test does match the condition requested [default:
-                                "Test condition matched"]
+      --term-old <TERM_OLD>     Text shown when a test does match the condition requested
       --test-dir <TEST_DIR>     Root directory for tests [default: .]
   -v, --verbose...              
   -V, --version                 Print version

--- a/tests/cmd/help.stdout
+++ b/tests/cmd/help.stdout
@@ -93,13 +93,9 @@ Options:
 
       --term-new <TERM_NEW>
           Text shown when a test fails to match the condition requested
-          
-          [default: "Test condition NOT matched"]
 
       --term-old <TERM_OLD>
           Text shown when a test does match the condition requested
-          
-          [default: "Test condition matched"]
 
       --test-dir <TEST_DIR>
           Root directory for tests


### PR DESCRIPTION
hey @ehuss :wave: 

this patch tries to implement your suggestion (see [comment](https://github.com/rust-lang/cargo-bisect-rustc/pull/330#discussion_r1583635275)) implementing reasonable defaults for `--term-old` and `--term-new`.

I've tried doing something that would not lead to confusion but I find the implementation confusing the same :smile: 

Is it just me? Any suggestion on how to improve?

Thanks