### PR TITLE
Add default regression terms based on `--regress` option.

### DIFF
--- a/guide/src/examples/diagnostics.md
+++ b/guide/src/examples/diagnostics.md
@@ -23,12 +23,14 @@ fi
 echo "$OUTPUT"
 # This indicates a regression when the text "non-ASCII" is in the output.
 #
-# If the regression is when the text is *not* in the output, remove the `!` prefix.
+# If the regression is when the text is *not* in the output, remove the `!` prefix
+# (and customize the `--term-old` and `--term-new` CLI options if you want).
 ! echo "$OUTPUT" | grep "non-ASCII"
 ```
 
 Then run something like:
 
 ```sh
-cargo bisect-rustc --start=1.67.0 --end=1.68.0 --script ./test.sh
+cargo bisect-rustc --start=1.67.0 --end=1.68.0 --script ./test.sh \
+    --term-old="No warning" --term-new="Found non-ASCII warning"
 ```

--- a/guide/src/examples/doc-change.md
+++ b/guide/src/examples/doc-change.md
@@ -27,7 +27,8 @@ fi
 And run with:
 
 ```sh
-cargo bisect-rustc --start 1.68.0 --end 1.69.0 -c rust-docs --script ./test.sh
+cargo bisect-rustc --start 1.68.0 --end 1.69.0 -c rust-docs --script ./test.sh \
+    --term-old="Did not find" --term-new="Found"
 ```
 
 > **Note**: This may not work on all targets since `cargo-bisect-rustc` doesn't properly handle rustup manifests, which alias some targets to other targets.

--- a/guide/src/examples/rustdoc.md
+++ b/guide/src/examples/rustdoc.md
@@ -27,5 +27,6 @@ grep "some example text" $CARGO_TARGET_DIR/doc/mycrate/fn.foo.html
 This can be used with the `--script` option:
 
 ```sh
-cargo-bisect-rustc --start=2023-01-22 --end=2023-03-18 --script=./test.sh
+cargo-bisect-rustc --start=2023-01-22 --end=2023-03-18 --script=./test.sh \
+    --term-old="Found example text" --term-new="Failed, or did not find text"
 ```

--- a/guide/src/tutorial.md
+++ b/guide/src/tutorial.md
@@ -138,7 +138,7 @@ cargo bisect-rustc --script=./test.sh \
 
 ## Custom bisection messages
 
-[Available from v0.6.9]
+*Available from v0.6.9*
 
 You can add custom messages when bisecting a regression. Taking inspiration from git-bisect, with `term-new` and `term-old` you can set custom messages to indicate if a regression matches the condition set by the bisection.
 
@@ -151,18 +151,8 @@ cargo bisect-rustc \
     --term-new "Yes, this build reproduces the regression, compile error"
 ```
 
-Note that `--term-{old,new}` are aware of the `--regress` parameter. If the bisection is looking for a build to reproduce a regression (i.e. `--regress {error,ice}`), `--term-old` indicates a point in time where the regression does not reproduce and `--term-new` indicates that it does.
+In other words, `--term-old` is displayed for older compilers that **do not** exhibit the regression. `--term-new` is for newer compilers which do exhibit the regression.
 
-On the other hand, if `--regress {non-error,non-ice,success}` you are looking into bisecting when a condition of error stopped being reproducible (e.g. some faulty code does not produce an error anymore). In this case `cargo-bisect` flips the meaning of these two parameters.
+What counts as a "regression" is defined by the [`--regress`](usage.html#regression-check) CLI option. By default, a regression is a compile-error (which is equivalent to `--term-new`). If you flip the definition of a "regression" with `--regress=success`, then a regression is a successful compile (which is *also* equivalent to `--term-new`).
 
-Example:
-```sh
-cargo bisect-rustc \
-    --start=2018-08-14 \
-    --end=2018-10-11 \
-    --regress=success \
-    --term-old "This build does not compile" \
-    --term-new "This build compiles"
-```
-
-See [`--regress`](usage.html#regression-check) for more details.
+There are default terms based on the current `--regress` setting. Customizing the terms is most useful when using [scripting](#testing-with-a-script). For example, in the [Documentation changes](examples/doc-change.md) example, the customized terms can more clearly express the results of the script of whether or not it found what it was looking for in the documentation.

--- a/src/least_satisfying.rs
+++ b/src/least_satisfying.rs
@@ -1,8 +1,6 @@
 use std::collections::BTreeMap;
 use std::fmt;
 
-use crate::RegressOn;
-
 pub fn least_satisfying<T, P>(slice: &[T], mut predicate: P) -> usize
 where
     T: fmt::Display + fmt::Debug,
@@ -175,27 +173,11 @@ pub enum Satisfies {
 }
 
 impl Satisfies {
-    pub fn msg_with_context(&self, regress: &RegressOn, term_old: &str, term_new: &str) -> String {
-        let msg_yes = if regress == &RegressOn::Error || regress == &RegressOn::Ice {
-            // YES: compiles, does not reproduce the regression
-            term_new
-        } else {
-            // NO: compile error, reproduces the regression
-            term_old
-        };
-
-        let msg_no = if regress == &RegressOn::Error || regress == &RegressOn::Ice {
-            // YES: compile error
-            term_old
-        } else {
-            // NO: compiles
-            term_new
-        };
-
+    pub fn msg_with_context<'a>(&self, term_old: &'a str, term_new: &'a str) -> &'a str {
         match self {
-            Self::Yes => msg_yes.to_string(),
-            Self::No => msg_no.to_string(),
-            Self::Unknown => "Unable to figure out if the condition matched".to_string(),
+            Self::Yes => term_new,
+            Self::No => term_old,
+            Self::Unknown => "Unable to figure out if the condition matched",
         }
     }
 }

--- a/tests/cmd/h.stdout
+++ b/tests/cmd/h.stdout
@@ -28,10 +28,8 @@ Options:
   -t, --timeout <TIMEOUT>       Assume failure after specified number of seconds (for bisecting
                                 hangs)
       --target <TARGET>         Cross-compilation target platform
-      --term-new <TERM_NEW>     Text shown when a test fails to match the condition requested
-                                [default: "Test condition NOT matched"]
-      --term-old <TERM_OLD>     Text shown when a test does match the condition requested [default:
-                                "Test condition matched"]
+      --term-new <TERM_NEW>     Text shown when a test does match the condition requested
+      --term-old <TERM_OLD>     Text shown when a test fails to match the condition requested
       --test-dir <TEST_DIR>     Root directory for tests [default: .]
   -v, --verbose...              
   -V, --version                 Print version

--- a/tests/cmd/help.stdout
+++ b/tests/cmd/help.stdout
@@ -92,14 +92,10 @@ Options:
           Cross-compilation target platform
 
       --term-new <TERM_NEW>
-          Text shown when a test fails to match the condition requested
-          
-          [default: "Test condition NOT matched"]
+          Text shown when a test does match the condition requested
 
       --term-old <TERM_OLD>
-          Text shown when a test does match the condition requested
-          
-          [default: "Test condition matched"]
+          Text shown when a test fails to match the condition requested
 
       --test-dir <TEST_DIR>
           Root directory for tests


### PR DESCRIPTION
This adds new default text for the regression status based on the `--regress` option. These terms will hopefully be clearer to understand as opposed to just saying "Yes" and "No". Although "Yes" and "No" are directly related to whether or not the regression was found, you have to have a mental map of Yes→Current Regression Mode→Compile Status. This hopes to shorten that to just "Compile Status".

To review the basics here:
* `RegressOn` is the `--regress` option.
* `Satisfies` is whether or not the "regression" was found. 
* The definition of "regression" depends on the `--regress` option. By default, it is `--regress=error` which means a regression occurs when it fails to compile.  `--regress=success` means the opposite (a regression is when it successfully compiles).
* `term-old` is the text displayed for compilers *older* than the date of the regression.
* `term-new` is the text displayed for compilers *on or after* the date of the regression.

Thus, "old" is equivalent to "Satisfies::No" and "new" is equivalent to "Satisfies::Yes".

Here is an abbreviated example of what this would look like on the console for the default `--regress=error`:

```
checking the start range to find a passing nightly
installing nightly-2024-03-15
testing...
RESULT: nightly-2024-03-15, ===> Successfully compiled

checking the end range to verify it does not pass
installing nightly-2024-04-15
testing...
RESULT: nightly-2024-04-15, ===> Compile error

16 versions remaining to test after this (roughly 5 steps)
installing nightly-2024-03-30
testing...
RESULT: nightly-2024-03-30, ===> Successfully compiled

8 versions remaining to test after this (roughly 4 steps)
installing nightly-2024-04-07
testing...
RESULT: nightly-2024-04-07, ===> Compile error

4 versions remaining to test after this (roughly 3 steps)
installing nightly-2024-04-03
testing...
RESULT: nightly-2024-04-03, ===> Compile error

2 versions remaining to test after this (roughly 2 steps)
installing nightly-2024-04-01
testing...
RESULT: nightly-2024-04-01, ===> Successfully compiled

1 versions remaining to test after this (roughly 1 steps)
installing nightly-2024-04-02
testing...
RESULT: nightly-2024-04-02, ===> Successfully compiled

searched toolchains nightly-2024-03-15 through nightly-2024-04-15
```

Here you can see it starts checking the start range (the "old" compiler) and finds the baseline successfully compiles. Then it checks the end range (the "new" compiler) and finds the regression ("Compile error").

The terms are essentially reversed for `--regress=success`.

You can customize these terms with `--term-old` and `--term-new`. This is mostly useful when using scripts or custom commands, which might provide confusing outputs when using the default `--regress=error`. Scripts might be inverting the logic themselves, or doing actions other than compiling (like grepping for docs).

This also corrects what I think was a misunderstanding in https://github.com/rust-lang/cargo-bisect-rustc/pull/330 when during review there was a change from `--term-good` and `--term-bad` where it did make sense to "flip" the meaning based on the regression mode. However, my intent with `--term-old` and `--term-new` is to avoid that flipping (and is also the reasoning I believe `git bisect` introduced the old/new terminology). "Old" means an older compiler by date, and "new" means a newer one. There's no need to flip the meaning.

I also customized the text when using the `--script` parameter, since scripts can do things other than "compiling", and the new default terms could otherwise be confusing. It now explicitly indicates what the script returned.
