### PR TITLE
Bump `proc-macro2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1055,9 +1055,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.46"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
This can't currently be built on nightly due to
```rs
error[E0635]: unknown feature `proc_macro_span_shrink`
  --> .../.cargo/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.46/src/lib.rs:92:30
   |
92 |     feature(proc_macro_span, proc_macro_span_shrink)

```