### PR TITLE
Print the command that is run if we are --verbose

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -226,6 +226,10 @@ impl Opts {
     fn emit_cargo_output(&self) -> bool {
         self.verbosity >= 2
     }
+
+    fn emit_cmd(&self) -> bool {
+        self.verbosity >= 1
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/toolchains.rs
+++ b/src/toolchains.rs
@@ -307,6 +307,10 @@ impl Toolchain {
         cmd.stdout(default_stdio());
         cmd.stderr(default_stdio());
 
+        if cfg.args.emit_cmd() {
+            eprintln!("Running `{cmd:?}`");
+        }
+
         let output = match cmd.output() {
             Ok(output) => output,
             Err(err) => {


### PR DESCRIPTION
This makes it easier to debug problems when you are doing tricky things like constructing the example command at https://github.com/rust-lang/cargo-bisect-rustc/pull/360.

Here is what the new `--verbose` output says if run with that example:
```
Running `cd "." && CARGO_TARGET_DIR="target-bisector-nightly-2023-03-31-x86_64-unknown-linux-gnu" RUSTUP_TOOLCHAIN="bisector-nightly-2023-03-31-x86_64-unknown-linux-gnu" "bash" "-c" "rustc -Cpasses=lint -Cinstrument-coverage --crate-type=dylib tests/ui/issues/issue-85461.rs 2>&1 | grep Undefined"`
````

Here is what it looks like with context:
```
checking the start range to find a passing nightly
installing nightly-2023-03-31
testing...
Running `cd "." && CARGO_TARGET_DIR="target-bisector-nightly-2023-03-31-x86_64-unknown-linux-gnu" RUSTUP_TOOLCHAIN="bisector-nightly-2023-03-31-x86_64-unknown-linux-gnu" "bash" "-c" "rustc -Cpasses=lint -Cinstrument-coverage --crate-type=dylib tests/ui/issues/issue-85461.rs 2>&1 | grep Undefined"`
RESULT: nightly-2023-03-31, ===> Script returned success

checking the end range to verify it does not pass
installing nightly-2023-12-21
testing...
Running `cd "." && CARGO_TARGET_DIR="target-bisector-nightly-2023-12-21-x86_64-unknown-linux-gnu" RUSTUP_TOOLCHAIN="bisector-nightly-2023-12-21-x86_64-unknown-linux-gnu" "bash" "-c" "rustc -Cpasses=lint -Cinstrument-coverage --crate-type=dylib tests/ui/issues/issue-85461.rs 2>&1 | grep Undefined"`
RESULT: nightly-2023-12-21, ===> Script returned error

133 versions remaining to test after this (roughly 8 steps)
installing nightly-2023-08-10
testing...
Running `cd "." && CARGO_TARGET_DIR="target-bisector-nightly-2023-08-10-x86_64-unknown-linux-gnu" RUSTUP_TOOLCHAIN="bisector-nightly-2023-08-10-x86_64-unknown-linux-gnu" "bash" "-c" "rustc -Cpasses=lint -Cinstrument-coverage --crate-type=dylib tests/ui/issues/issue-85461.rs 2>&1 | grep Undefined"`
RESULT: nightly-2023-08-10, ===> Script returned error
```