### PR TITLE
Add another example for hanging compilation

### DIFF
--- a/guide/src/examples/slow.md
+++ b/guide/src/examples/slow.md
@@ -29,3 +29,21 @@ cargo-bisect-rustc --start=2021-09-01 --end=2021-10-02 --timeout 30 -- build --r
 You may need to adjust the timeout value based on the speed of your system.
 
 > **Note**: `--timeout` is currently not working on macOS. See <https://github.com/rust-lang/cargo-bisect-rustc/issues/232>.
+
+In some cases bisecting if a timeout happens is not enough, there might also be a compilation error (see for example [rustc#139197](https://github.com/rust-lang/rust/issues/139197)). In this case the script should handle all the work, here's a Bash example (given `main.rs` is the Rust code to reproduce the hanging compilation):
+```sh
+#!/bin/bash
+res=$( timeout 3 rustc main.rs )
+if [ "$?" -eq 124 ]; then
+    # Excessive compile time
+    exit 1
+else
+    # Compilation fails as expected *but* it doesn't hang
+    exit 0
+fi
+```
+
+and then run (example):
+```sh
+cargo-bisect-rustc [...params...] --script test.sh
+```


### PR DESCRIPTION
While bisecting [rust#139197](https://togithub.com/rust-lang/rust/issues/139197), I spent more time than I wanted to figure out how to bisect a hanging compilation of some code that should not compile anyway.

Could this case be useful in the documentation?

Thanks