### PR TITLE
Use `rust-lang/rust` instead of `rust-lang-ci/rust` for unrolled rollup build commit URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Dev
+
+### Changed
+- Unrolled CI builds have moved from the `rust-lang-ci/rust` repository to the `rust-lang/rust` repository.
+
 ## v0.6.9
 
 ### Added

--- a/src/main.rs
+++ b/src/main.rs
@@ -456,12 +456,18 @@ impl Config {
             Ok(result) => {
                 let bisection = result.bisection;
                 let url = format!(
+                    "https://github.com/rust-lang/rust/commit/{}",
+                    bisection.searched[bisection.found]
+                )
+                .red()
+                .bold();
+                let legacy_url = format!(
                     "https://github.com/rust-lang-ci/rust/commit/{}",
                     bisection.searched[bisection.found]
                 )
                 .red()
                 .bold();
-                eprintln!("Regression in {url}");
+                eprintln!("Regression in {url}. Note that if it is a legacy rollup build, it might be available in {legacy_url}.");
 
                 // In case the bisected commit has been garbage-collected by github, we show its
                 // additional context here.
@@ -1330,14 +1336,14 @@ mod tests {
 
 |PR# | Perf Build Sha|
 |----|:-----:|
-|#113009|[05b07dad146a6d43ead9bcd1e8bc10cbd017a5f5](https://github.com/rust-lang-ci/rust/commit/05b07dad146a6d43ead9bcd1e8bc10cbd017a5f5)|
-|#113008|[581913b6789370def5158093b799baa6d4d875eb](https://github.com/rust-lang-ci/rust/commit/581913b6789370def5158093b799baa6d4d875eb)|
-|#112956|[e294bd3827eb2e878167329648f3c8178ef344e7](https://github.com/rust-lang-ci/rust/commit/e294bd3827eb2e878167329648f3c8178ef344e7)|
-|#112950|[0ed6ba504649ca1cb2672572b4ab41acfb06c86c](https://github.com/rust-lang-ci/rust/commit/0ed6ba504649ca1cb2672572b4ab41acfb06c86c)|
-|#112937|[18e108ab85b78e6966c5b5bdadfd5b8efeadf080](https://github.com/rust-lang-ci/rust/commit/18e108ab85b78e6966c5b5bdadfd5b8efeadf080)|
+|#113009|[05b07dad146a6d43ead9bcd1e8bc10cbd017a5f5](https://github.com/rust-lang/rust/commit/05b07dad146a6d43ead9bcd1e8bc10cbd017a5f5)|
+|#113008|[581913b6789370def5158093b799baa6d4d875eb](https://github.com/rust-lang/rust/commit/581913b6789370def5158093b799baa6d4d875eb)|
+|#112956|[e294bd3827eb2e878167329648f3c8178ef344e7](https://github.com/rust-lang/rust/commit/e294bd3827eb2e878167329648f3c8178ef344e7)|
+|#112950|[0ed6ba504649ca1cb2672572b4ab41acfb06c86c](https://github.com/rust-lang/rust/commit/0ed6ba504649ca1cb2672572b4ab41acfb06c86c)|
+|#112937|[18e108ab85b78e6966c5b5bdadfd5b8efeadf080](https://github.com/rust-lang/rust/commit/18e108ab85b78e6966c5b5bdadfd5b8efeadf080)|
 
 
-*previous master*: [f7ca9df695](https://github.com/rust-lang-ci/rust/commit/f7ca9df69549470541fbf542f87a03eb9ed024b6)
+*previous master*: [f7ca9df695](https://github.com/rust-lang/rust/commit/f7ca9df69549470541fbf542f87a03eb9ed024b6)
 
 In the case of a perf regression, run the following command for each PR you suspect might be the cause: `@rust-timer build $SHA`
 <!-- rust-timer: rollup -->";
@@ -1368,17 +1374,17 @@ In the case of a perf regression, run the following command for each PR you susp
 
 | PR# | Message | Perf Build Sha |
 |----|----|:-----:|
-|#112207|Add trustzone and virtualization target features for aarch3…|`bbec6d6e413aa144c8b9346da27a0f2af299cbeb` ([link](https://github.com/rust-lang-ci/rust/commit/bbec6d6e413aa144c8b9346da27a0f2af299cbeb))|
-|#112454|Make compiletest aware of targets without dynamic linking|`70b67c09ead52f4582471650202b1a189821ed5f` ([link](https://github.com/rust-lang-ci/rust/commit/70b67c09ead52f4582471650202b1a189821ed5f))|
-|#112628|Allow comparing `Box`es with different allocators|`3043f4e577f41565443f38a6a16b7a1a08b063ad` ([link](https://github.com/rust-lang-ci/rust/commit/3043f4e577f41565443f38a6a16b7a1a08b063ad))|
-|#112692|Provide more context for `rustc +nightly -Zunstable-options…|`4ab6f33fd50237b105999cc6d32d85cce5dad61a` ([link](https://github.com/rust-lang-ci/rust/commit/4ab6f33fd50237b105999cc6d32d85cce5dad61a))|
-|#112972|Make `UnwindAction::Continue` explicit in MIR dump|`e1df9e306054655d7d41ec1ad75ade5d76a6888d` ([link](https://github.com/rust-lang-ci/rust/commit/e1df9e306054655d7d41ec1ad75ade5d76a6888d))|
-|#113020|Add tests impl via obj unless denied|`affe009b94eba41777cf02997b1780e50445d6af` ([link](https://github.com/rust-lang-ci/rust/commit/affe009b94eba41777cf02997b1780e50445d6af))|
-|#113084|Simplify some conditions|`0ce4618dbf5810aabb389edd4950c060b6b4d049` ([link](https://github.com/rust-lang-ci/rust/commit/0ce4618dbf5810aabb389edd4950c060b6b4d049))|
-|#113103|Normalize types when applying uninhabited predicate.|`241cd8cd818cdc865cdf02f0c32a40081420b772` ([link](https://github.com/rust-lang-ci/rust/commit/241cd8cd818cdc865cdf02f0c32a40081420b772))|
+|#112207|Add trustzone and virtualization target features for aarch3…|`bbec6d6e413aa144c8b9346da27a0f2af299cbeb` ([link](https://github.com/rust-lang/rust/commit/bbec6d6e413aa144c8b9346da27a0f2af299cbeb))|
+|#112454|Make compiletest aware of targets without dynamic linking|`70b67c09ead52f4582471650202b1a189821ed5f` ([link](https://github.com/rust-lang/rust/commit/70b67c09ead52f4582471650202b1a189821ed5f))|
+|#112628|Allow comparing `Box`es with different allocators|`3043f4e577f41565443f38a6a16b7a1a08b063ad` ([link](https://github.com/rust-lang/rust/commit/3043f4e577f41565443f38a6a16b7a1a08b063ad))|
+|#112692|Provide more context for `rustc +nightly -Zunstable-options…|`4ab6f33fd50237b105999cc6d32d85cce5dad61a` ([link](https://github.com/rust-lang/rust/commit/4ab6f33fd50237b105999cc6d32d85cce5dad61a))|
+|#112972|Make `UnwindAction::Continue` explicit in MIR dump|`e1df9e306054655d7d41ec1ad75ade5d76a6888d` ([link](https://github.com/rust-lang/rust/commit/e1df9e306054655d7d41ec1ad75ade5d76a6888d))|
+|#113020|Add tests impl via obj unless denied|`affe009b94eba41777cf02997b1780e50445d6af` ([link](https://github.com/rust-lang/rust/commit/affe009b94eba41777cf02997b1780e50445d6af))|
+|#113084|Simplify some conditions|`0ce4618dbf5810aabb389edd4950c060b6b4d049` ([link](https://github.com/rust-lang/rust/commit/0ce4618dbf5810aabb389edd4950c060b6b4d049))|
+|#113103|Normalize types when applying uninhabited predicate.|`241cd8cd818cdc865cdf02f0c32a40081420b772` ([link](https://github.com/rust-lang/rust/commit/241cd8cd818cdc865cdf02f0c32a40081420b772))|
 
 
-*previous master*: [5ea6668646](https://github.com/rust-lang-ci/rust/commit/5ea66686467d3ec5f8c81570e7f0f16ad8dd8cc3)
+*previous master*: [5ea6668646](https://github.com/rust-lang/rust/commit/5ea66686467d3ec5f8c81570e7f0f16ad8dd8cc3)
 
 In the case of a perf regression, run the following command for each PR you suspect might be the cause: `@rust-timer build $SHA`
 <!-- rust-timer: rollup -->";


### PR DESCRIPTION
We have moved CI from `rust-lang-ci/rust` to `rust-lang/rust`, so this can be merged now.

Context: https://github.com/rust-lang/infra-team/issues/188