### PR TITLE
Add a publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,24 @@
+name: Publish
+on:
+  release:
+    types: [created]
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust (rustup)
+        run: rustup update stable --no-self-update && rustup default stable
+      - name: Publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --no-verify

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -1,0 +1,16 @@
+# Maintaining cargo-bisect-rustc
+
+## Publishing
+
+To publish a new release:
+
+1. Create a PR to bump the version in `Cargo.toml` and `Cargo.lock`, and update [`CHANGELOG.md`](CHANGELOG.md).
+2. After the merge is complete, create a new release. There are two approaches:
+    - GUI: Create a new release in the UI, tag and title should be `v` and the version number. Copy a link to the changelog.
+    - CLI: Run the following in the repo:
+        ```bash
+        VERSION="`cargo read-manifest | jq -r .version`" ; \
+            gh release create -R rust-lang/cargo-bisect-rustc v$VERSION \
+                --title v$VERSION \
+                --notes "See https://github.com/rust-lang/cargo-bisect-rustc/blob/master/CHANGELOG.md#v${VERSION//.} for a complete list of changes."
+        ```


### PR DESCRIPTION
This adds a workflow to publish cargo-bisect-rustc to crates.io from CI.