### PR TITLE
Improve tutorial for new users

### DIFF
--- a/guide/src/boundaries.md
+++ b/guide/src/boundaries.md
@@ -29,6 +29,8 @@ cargo bisect-rustc --start=2018-08-14 --end=2018-10-11
 
 If the nightly with the regression was within the past 167 days, then it will automatically start bisecting the individual PRs merged on that day using [Git commit boundaries](#git-commit-boundaries).
 
+> **Note**: A pitfall is that if you use something like `rustc +nightly --version` to figure out the version you are on it will often identify a date that is one day early from the nightly toolchain version. E.g. `nightly-2025-07-19` will say `2025-07-18`, since that is when the most recent commit was merged, even though the toolchain was published on the 19th.
+
 ## Git commit boundaries
 
 You can pass the particular git commit hash of a PR as a boundary.

--- a/guide/src/tutorial.md
+++ b/guide/src/tutorial.md
@@ -49,10 +49,14 @@ It will do a binary search between the start and end range to find exactly where
 
 [`--regress`]: usage.md#regression-check
 
-In our example, in just a few steps, we can we find that it stopped working on `nightly-2018-07-30`.
+> **Note**: Additional ways to specify boundaries include stable versions and git commit hashes. See the [Bisection boundaries] chapter for more details on setting these options.
+
+[Bisection boundaries]: boundaries.md
+
+In our example, in just a few steps, we can find that it stopped working on `nightly-2018-07-30`.
 
 If the regression is recent enough, then it will print out a list of PRs that were committed on that date.
-In this particular example, it is too old, so we'll need to manually inspect the git log to see which PR's were merged.
+In this particular example, it is too old, so we'll need to manually inspect the git log to see which PRs were merged.
 
 If the nightly was within the last 167 days, then `cargo-bisect-rustc` will then start bisecting those individual PRs.
 


### PR DESCRIPTION
* Mention support for tags, in particular stable releases.
* Mention that nightly --version might "lie" about their dates.
* Also fix some small typos in nearby paragraphs that I noticed.

I feel like the tutorial in particular should be aimed at people who don't normally use nightly but reported a regression for rust and are being told that a bisect would be useful. These were two stumbling blocks I ran into: finding out how to map stable versions to nightly dates, and that my end point nightly "lied" about which date it was.