### PR TITLE
Rename all occurrences of master to HEAD

### DIFF
--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -93,7 +93,7 @@ impl Bounds {
             }
             (Some(Bound::Commit(start)), None) => Bounds::Commits {
                 start,
-                end: args.access.repo().commit("origin/master")?.sha,
+                end: args.access.repo().commit("origin/HEAD")?.sha,
             },
             (None, Some(Bound::Commit(end))) => Bounds::Commits {
                 start: EPOCH_COMMIT.to_string(),

--- a/src/github.rs
+++ b/src/github.rs
@@ -221,16 +221,16 @@ impl ToUrl for CommitsUrl<'_> {
 
 impl ToUrl for CommitDetailsUrl<'_> {
     fn url(&self) -> String {
-        // "origin/master" is set as `sha` when there is no `--end=` definition
-        // specified on the command line.  We define the GitHub master branch
+        // "origin/HEAD" is set as `sha` when there is no `--end=` definition
+        // specified on the command line.  We define the GitHub HEAD branch
         // HEAD commit as the end commit in this case
-        let reference = if self.sha == "origin/master" {
-            "master"
+        let reference = if self.sha == "origin/HEAD" {
+            "HEAD"
         } else {
             self.sha
         };
 
-        format!("https://api.github.com/repos/{OWNER}/{REPO}/compare/master...{reference}")
+        format!("https://api.github.com/repos/{OWNER}/{REPO}/compare/HEAD...{reference}")
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -994,7 +994,7 @@ impl Config {
             if c.committer.name != BORS_AUTHOR {
                 bail!(
                     "Expected author {} to be {BORS_AUTHOR} for {}.\n \
-                     Make sure specified commits are on the master branch \
+                     Make sure specified commits are on the HEAD branch \
                      and refer to a bors merge commit!",
                     c.committer.name,
                     c.sha
@@ -1337,7 +1337,7 @@ mod tests {
 |#112937|[18e108ab85b78e6966c5b5bdadfd5b8efeadf080](https://github.com/rust-lang-ci/rust/commit/18e108ab85b78e6966c5b5bdadfd5b8efeadf080)|
 
 
-*previous master*: [f7ca9df695](https://github.com/rust-lang-ci/rust/commit/f7ca9df69549470541fbf542f87a03eb9ed024b6)
+*previous HEAD*: [f7ca9df695](https://github.com/rust-lang-ci/rust/commit/f7ca9df69549470541fbf542f87a03eb9ed024b6)
 
 In the case of a perf regression, run the following command for each PR you suspect might be the cause: `@rust-timer build $SHA`
 <!-- rust-timer: rollup -->";
@@ -1378,7 +1378,7 @@ In the case of a perf regression, run the following command for each PR you susp
 |#113103|Normalize types when applying uninhabited predicate.|`241cd8cd818cdc865cdf02f0c32a40081420b772` ([link](https://github.com/rust-lang-ci/rust/commit/241cd8cd818cdc865cdf02f0c32a40081420b772))|
 
 
-*previous master*: [5ea6668646](https://github.com/rust-lang-ci/rust/commit/5ea66686467d3ec5f8c81570e7f0f16ad8dd8cc3)
+*previous HEAD*: [5ea6668646](https://github.com/rust-lang-ci/rust/commit/5ea66686467d3ec5f8c81570e7f0f16ad8dd8cc3)
 
 In the case of a perf regression, run the following command for each PR you suspect might be the cause: `@rust-timer build $SHA`
 <!-- rust-timer: rollup -->";

--- a/src/repo_access.rs
+++ b/src/repo_access.rs
@@ -12,7 +12,7 @@ pub(crate) trait RustRepositoryAccessor {
     }
 
     /// Looks up commit associated with `commit_ref`, which can be either a sha
-    /// or a more general reference like "origin/master".
+    /// or a more general reference like "origin/HEAD".
     fn commit(&self, commit_ref: &str) -> anyhow::Result<Commit>;
 
     /// Looks up a series of commits ending with `end_sha`; the resulting series
@@ -31,7 +31,7 @@ impl RustRepositoryAccessor for AccessViaLocalGit {
         git::get_commit(commit_ref)
     }
     fn commits(&self, start_sha: &str, end_sha: &str) -> anyhow::Result<Vec<Commit>> {
-        let end_sha = if end_sha == "origin/master" {
+        let end_sha = if end_sha == "origin/HEAD" {
             "FETCH_HEAD"
         } else {
             end_sha


### PR DESCRIPTION
Follow up to the renaming of the HEAD on `rust-lang/rust`