### PR TITLE
Display and stop on installation error in perf search

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1178,11 +1178,18 @@ impl Config {
             })
             .collect::<Vec<_>>();
 
-        let Some(found) = toolchains.iter().position(|t| {
-            self.install_and_test(t, &dl_spec)
-                .unwrap_or(Satisfies::Unknown)
-                == Satisfies::Yes
-        }) else {
+        let mut found = None;
+        for (i, t) in toolchains.iter().enumerate() {
+            match self.install_and_test(t, &dl_spec) {
+                Ok(Satisfies::Yes) => {
+                    found = Some(i);
+                    break;
+                }
+                Ok(_) => {}
+                Err(e) => bail!("error: {e}"),
+            }
+        }
+        let Some(found) = found else {
             bail!("none of the toolchains satisfied the predicate");
         };
 


### PR DESCRIPTION
This changes the linear search done in the unrolled perf search so that it displays an error if it is unable to install a toolchain. Previously it would silently try each unrolled build in sequence.

Additionally this stops the search if there is an install error. I think this is the correct behavior, because:

- In most cases, if one install fails, all of them will fail.
- If in a rare case where some succeed, but some fail, it would be incorrect to try any of the ones after the failure because it could incorrectly report the regression in a PR that just happens to land after a PR that failed to install but was the real culprit.