### PR TITLE
Add verbiage to --help

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -146,7 +146,7 @@ struct Opts {
 
     #[arg(
         short, long = "verbose",
-        help = "Multiple -v options increase verbosity, including the output of the bisection command. The maximum is 2.",
+        help = "Multiple -v options increase verbosity. At level 2, the output of the bisection command is shown.",
         action = ArgAction::Count)]
     verbosity: u8,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,7 +144,10 @@ struct Opts {
     )]
     timeout: Option<usize>,
 
-    #[arg(short, long = "verbose", action = ArgAction::Count)]
+    #[arg(
+        short, long = "verbose",
+        help = "Multiple -v options increase verbosity, including the output of the bisection command. The maximum is 2.",
+        action = ArgAction::Count)]
     verbosity: u8,
 
     #[arg(

--- a/tests/cmd/bare-h.stdout
+++ b/tests/cmd/bare-h.stdout
@@ -33,7 +33,8 @@ Options:
       --term-new <TERM_NEW>     Text shown when a test does match the condition requested
       --term-old <TERM_OLD>     Text shown when a test fails to match the condition requested
       --test-dir <TEST_DIR>     Root directory for tests [default: .]
-  -v, --verbose...              
+  -v, --verbose...              Multiple -v options increase verbosity, including the output of the
+                                bisection command. The maximum is 2.
   -V, --version                 Print version
       --with-dev                Download rustc-dev [default: no download]
       --with-src                Download rust-src [default: no download]

--- a/tests/cmd/bare-h.stdout
+++ b/tests/cmd/bare-h.stdout
@@ -33,8 +33,8 @@ Options:
       --term-new <TERM_NEW>     Text shown when a test does match the condition requested
       --term-old <TERM_OLD>     Text shown when a test fails to match the condition requested
       --test-dir <TEST_DIR>     Root directory for tests [default: .]
-  -v, --verbose...              Multiple -v options increase verbosity, including the output of the
-                                bisection command. The maximum is 2.
+  -v, --verbose...              Multiple -v options increase verbosity. At level 2, the output of
+                                the bisection command is shown.
   -V, --version                 Print version
       --with-dev                Download rustc-dev [default: no download]
       --with-src                Download rust-src [default: no download]

--- a/tests/cmd/bare-help.stdout
+++ b/tests/cmd/bare-help.stdout
@@ -107,7 +107,8 @@ Options:
           [default: .]
 
   -v, --verbose...
-          
+          Multiple -v options increase verbosity, including the output of the bisection command. The
+          maximum is 2.
 
   -V, --version
           Print version

--- a/tests/cmd/bare-help.stdout
+++ b/tests/cmd/bare-help.stdout
@@ -107,8 +107,8 @@ Options:
           [default: .]
 
   -v, --verbose...
-          Multiple -v options increase verbosity, including the output of the bisection command. The
-          maximum is 2.
+          Multiple -v options increase verbosity. At level 2, the output of the bisection command is
+          shown.
 
   -V, --version
           Print version

--- a/tests/cmd/h.stdout
+++ b/tests/cmd/h.stdout
@@ -33,7 +33,8 @@ Options:
       --term-new <TERM_NEW>     Text shown when a test does match the condition requested
       --term-old <TERM_OLD>     Text shown when a test fails to match the condition requested
       --test-dir <TEST_DIR>     Root directory for tests [default: .]
-  -v, --verbose...              
+  -v, --verbose...              Multiple -v options increase verbosity, including the output of the
+                                bisection command. The maximum is 2.
   -V, --version                 Print version
       --with-dev                Download rustc-dev [default: no download]
       --with-src                Download rust-src [default: no download]

--- a/tests/cmd/h.stdout
+++ b/tests/cmd/h.stdout
@@ -33,8 +33,8 @@ Options:
       --term-new <TERM_NEW>     Text shown when a test does match the condition requested
       --term-old <TERM_OLD>     Text shown when a test fails to match the condition requested
       --test-dir <TEST_DIR>     Root directory for tests [default: .]
-  -v, --verbose...              Multiple -v options increase verbosity, including the output of the
-                                bisection command. The maximum is 2.
+  -v, --verbose...              Multiple -v options increase verbosity. At level 2, the output of
+                                the bisection command is shown.
   -V, --version                 Print version
       --with-dev                Download rustc-dev [default: no download]
       --with-src                Download rust-src [default: no download]

--- a/tests/cmd/help.stdout
+++ b/tests/cmd/help.stdout
@@ -107,7 +107,8 @@ Options:
           [default: .]
 
   -v, --verbose...
-          
+          Multiple -v options increase verbosity, including the output of the bisection command. The
+          maximum is 2.
 
   -V, --version
           Print version

--- a/tests/cmd/help.stdout
+++ b/tests/cmd/help.stdout
@@ -107,8 +107,8 @@ Options:
           [default: .]
 
   -v, --verbose...
-          Multiple -v options increase verbosity, including the output of the bisection command. The
-          maximum is 2.
+          Multiple -v options increase verbosity. At level 2, the output of the bisection command is
+          shown.
 
   -V, --version
           Print version


### PR DESCRIPTION
From [comment](https://github.com/rust-lang/cargo-bisect-rustc/issues/205#issuecomment-5236529424)

Now the help mentions that `verbose` can be double  :)

```
-v, --verbose...
          Multiple -v options increase verbosity, including the output of the bisection command. The maximum is 2.
```

@RalfJung does it look better? 